### PR TITLE
Add type alias for JSON payloads

### DIFF
--- a/Pod/Podfile.lock
+++ b/Pod/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Tailor (0.1)
+  - Tailor (0.1.1)
 
 DEPENDENCIES:
   - Tailor (from `../`)
 
 EXTERNAL SOURCES:
   Tailor:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Tailor: 93fbe179828c304c63f582f6f955bc1071a091ea
+  Tailor: bb8aa0648fcad41b30169c2ba6af61e23797be64
 
 COCOAPODS: 0.39.0.beta.4

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -1,4 +1,6 @@
 infix operator <- {}
+public typealias JSONArray = [[String : AnyObject]]
+public typealias JSONDictionary = [String : AnyObject]
 
 public func <- <T>(inout left: T, right: T) {
   left = right


### PR DESCRIPTION
Added two type alias

```swift
public typealias JSONArray = [[String : AnyObject]]
public typealias JSONDictionary = [String : AnyObject]
```

Now you no longer need to have `[String : AnyObject]` floating around in your code.