### PR TITLE
Add relation mapping and improve public API

### DIFF
--- a/Pod/Podfile.lock
+++ b/Pod/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - Tailor (0.1)
+  - Tailor (0.1.1)
 
 DEPENDENCIES:
   - Tailor (from `../`)
 
 EXTERNAL SOURCES:
   Tailor:
-    :path: ../
+    :path: "../"
 
 SPEC CHECKSUMS:
-  Tailor: 93fbe179828c304c63f582f6f955bc1071a091ea
+  Tailor: bb8aa0648fcad41b30169c2ba6af61e23797be64
 
 COCOAPODS: 0.39.0.beta.4

--- a/Pod/Tests/TestMappable.swift
+++ b/Pod/Tests/TestMappable.swift
@@ -77,7 +77,7 @@ class TestMappable: XCTestCase {
         ["firstName" : "Mini-Mini",
         "lastName" : "Swift",
         "sex": "female",
-        "birth_date": "2014-07-17"]
+        "birth_date": "2014-07-18"]
       ]
       ])
 
@@ -85,7 +85,9 @@ class TestMappable: XCTestCase {
     XCTAssertEqual(testStruct.lastName, expectedStruct.lastName)
     XCTAssertEqual(testStruct.sex, expectedStruct.sex)
     XCTAssertEqual(testStruct.birthDate, expectedStruct.birthDate)
-    XCTAssertTrue(testStruct.relatives.count > 0)
+    XCTAssertTrue(testStruct.relatives.count == 2)
     XCTAssertEqual(testStruct.relatives[0], relationStruct)
+    XCTAssertEqual(testStruct.relatives[0].firstName, "Mini")
+    XCTAssertEqual(testStruct.relatives[1].firstName, "Mini-Mini")
   }
 }

--- a/Pod/Tests/TestMappable.swift
+++ b/Pod/Tests/TestMappable.swift
@@ -49,4 +49,43 @@ class TestMappable: XCTestCase {
     XCTAssertEqual(testClass.sex, expectedClass.sex)
     XCTAssertEqual(testClass.birthDate, expectedClass.birthDate)
   }
+
+  func testRelations() {
+    let relationStruct = TestPersonStruct([
+        "firstName" : "Mini",
+        "lastName" : "Swift",
+        "sex": "female",
+        "birth_date": "2014-07-15"
+        ])
+    var expectedStruct = TestPersonStruct([:])
+    expectedStruct.firstName = "Taylor"
+    expectedStruct.lastName = "Swift"
+    expectedStruct.sex = .Female
+    expectedStruct.birthDate = dateFormatter.dateFromString("2014-07-15")!
+    expectedStruct.relatives.append(relationStruct)
+
+    let testStruct = TestPersonStruct([
+      "firstName" : "Taylor",
+      "lastName" : "Swift",
+      "sex": "female",
+      "birth_date": "2014-07-15",
+      "relatives" : [
+        ["firstName" : "Mini",
+        "lastName" : "Swift",
+        "sex": "female",
+        "birth_date": "2014-07-17"],
+        ["firstName" : "Mini-Mini",
+        "lastName" : "Swift",
+        "sex": "female",
+        "birth_date": "2014-07-17"]
+      ]
+      ])
+
+    XCTAssertEqual(testStruct.firstName, expectedStruct.firstName)
+    XCTAssertEqual(testStruct.lastName, expectedStruct.lastName)
+    XCTAssertEqual(testStruct.sex, expectedStruct.sex)
+    XCTAssertEqual(testStruct.birthDate, expectedStruct.birthDate)
+    XCTAssertTrue(testStruct.relatives.count > 0)
+    XCTAssertEqual(testStruct.relatives[0], relationStruct)
+  }
 }

--- a/Pod/Tests/TestSubjects.swift
+++ b/Pod/Tests/TestSubjects.swift
@@ -13,28 +13,22 @@ class TestPersonClass: NSObject, Inspectable, Mappable {
   var lastName: String? = ""
   var sex: Sex = .Unspecified
   var birthDate: NSDate?
-  
+
   required convenience init(_ map: [String : AnyObject]) {
     self.init()
     firstName <- map.property("firstName")
     lastName  <- map.property("lastName")
 
-    sex <- map.propertyWithTransform("sex") { (value: String?) -> Sex? in
-      var result: Sex?
-      if let value = value {
-        result = Sex(rawValue: value)
-      }
-      return result
+    sex <- map.transform("sex") { (value: String?) -> Sex? in
+      guard let value = value else { return nil }
+      return Sex(rawValue: value)
     }
 
-    birthDate <- map.propertyWithTransform("birth_date") { (value: String?) -> NSDate? in
-      var result: NSDate?
-      if let value = value {
-        let dateFormatter = NSDateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        result = dateFormatter.dateFromString(value)
-      }
-      return result
+    birthDate <- map.transform("birth_date") { (value: String?) -> NSDate? in
+      guard let value = value else { return nil }
+      let dateFormatter = NSDateFormatter()
+      dateFormatter.dateFormat = "yyyy-MM-dd"
+      return dateFormatter.dateFromString(value)
     }
   }
 
@@ -49,28 +43,30 @@ struct TestPersonStruct: Inspectable, Equatable {
   var lastName: String? = ""
   var sex: Sex?
   var birthDate = NSDate(timeIntervalSince1970: 1)
+  var relatives = [TestPersonStruct]()
 
   init(_ map: [String : AnyObject]) {
     firstName <- map.property("firstName")
     lastName  <- map.property("lastName")
 
-    sex <- map.propertyWithTransform("sex") { (value: String?) -> Sex? in
-      var result: Sex?
-      if let value = value {
-        result = Sex(rawValue: value)
-      }
-      return result
+    sex <- map.transform("sex") { (value: String?) -> Sex? in
+      guard let value = value else { return nil }
+      return Sex(rawValue: value)
     }
 
-    birthDate <- map.propertyWithTransform("birth_date") { (value: String?) -> NSDate? in
-      var result: NSDate?
-      if let value = value {
-        let dateFormatter = NSDateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-        result = dateFormatter.dateFromString(value)
-      }
-      return result
+    birthDate <- map.transform("birth_date") { (value: String?) -> NSDate? in
+      guard let value = value else { return nil }
+      let dateFormatter = NSDateFormatter()
+      dateFormatter.dateFormat = "yyyy-MM-dd"
+      return dateFormatter.dateFromString(value)
     }
+
+    relatives <- map.relation("relatives") { (objects: [[String : AnyObject]]?) -> [TestPersonStruct]? in
+      guard let objects = objects else { return self.relatives }
+      for object in objects { self.relatives.append(TestPersonStruct(object)) }
+      return self.relatives
+    }
+
   }
 }
 

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -76,4 +76,16 @@ public extension Dictionary {
     }
     return result
   }
+
+  func relation<T, U>(name: String, transform: ((value: U?) -> T?)? = nil) -> T? {
+    guard let key = name as? Key, value = self[key] else { return nil }
+
+    let result: T?
+    if let transform = transform {
+      result = transform(value: self[key] as? U)
+    } else {
+      result = value as? T
+    }
+    return result
+  }
 }

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -65,7 +65,7 @@ public extension Dictionary {
     return value as? T
   }
 
-  func propertyWithTransform<T, U>(name: String, transform: ((value: U?) -> T?)? = nil) -> T? {
+  func transform<T, U>(name: String, transform: ((value: U?) -> T?)? = nil) -> T? {
     guard let value = self[name as! Key] else { return nil }
 
     let result: T?

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -61,7 +61,7 @@ public extension Inspectable {
 public extension Dictionary {
 
   func property<T>(name: String) -> T? {
-    guard let value = self[name as! Key] else { return nil }
+    guard let key = name as? Key, value = self[key] else { return nil }
     return value as? T
   }
 

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -67,25 +67,13 @@ public extension Dictionary {
 
   func transform<T, U>(name: String, transform: ((value: U?) -> T?)? = nil) -> T? {
     guard let value = self[name as! Key] else { return nil }
-
-    let result: T?
-    if let transform = transform {
-      result = transform(value: value as? U)
-    } else {
-      result = value as? T
-    }
-    return result
+    guard let transform = transform else { return value as? T }
+    return transform(value: value as? U)
   }
 
   func relation<T, U>(name: String, transform: ((value: U?) -> T?)? = nil) -> T? {
     guard let key = name as? Key, value = self[key] else { return nil }
-
-    let result: T?
-    if let transform = transform {
-      result = transform(value: self[key] as? U)
-    } else {
-      result = value as? T
-    }
-    return result
+    guard let transform = transform else { return value as? T }
+    return transform(value: self[key] as? U)
   }
 }

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -26,11 +26,9 @@ public extension Inspectable {
 
     var result = value as? T
     let type:_MirrorType = _reflect(value)
-    if type.disposition == .Optional {
-      if type.count != 0 {
-        let (_, some) = type[0]
-        result = some.value as? T
-      }
+    if type.disposition == .Optional && type.count != 0 {
+      let (_, some) = type[0]
+      result = some.value as? T
     }
 
     return result


### PR DESCRIPTION
You can now map object relations, this is the first iteration so I think it can improve a lot in terms of the public API, but it works :sunglasses:

## Model usage
```swift
relatives <- map.relation("relatives") { (objects: [[String : AnyObject]]?) -> [TestPersonStruct]? in
  guard let objects = objects else { return self.relatives }
  for object in objects { self.relatives.append(TestPersonStruct(object)) }
  return self.relatives
}
```

## Controller usage
```swift
let testStruct = TestPersonStruct([
    "firstName" : "Taylor",
    "lastName" : "Swift",
    "sex": "female",
    "birth_date": "2014-07-15",
    "relatives" : [
      ["firstName" : "Mini",
      "lastName" : "Swift",
      "sex": "female",
      "birth_date": "2014-07-17"],
      ["firstName" : "Mini-Mini",
      "lastName" : "Swift",
      "sex": "female",
      "birth_date": "2014-07-17"]
    ]
])
```