### PR TITLE
Initial implementation of inspectable nested attributes

### DIFF
--- a/Pod/Pod.xcodeproj/project.pbxproj
+++ b/Pod/Pod.xcodeproj/project.pbxproj
@@ -8,7 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		64F2A17D596D0A5134BA7475 /* Pods.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 174DF0D5891FAF41A24E6525 /* Pods.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		BD25770B1BA2C72700BF7559 /* TestReflectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD25770A1BA2C72700BF7559 /* TestReflectable.swift */; settings = {ASSET_TAGS = (); }; };
+		BD25770B1BA2C72700BF7559 /* TestInspectable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD25770A1BA2C72700BF7559 /* TestInspectable.swift */; settings = {ASSET_TAGS = (); }; };
 		BD25770D1BA2C91E00BF7559 /* TestMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD25770C1BA2C91E00BF7559 /* TestMappable.swift */; settings = {ASSET_TAGS = (); }; };
 		BD25770F1BA2C95A00BF7559 /* TestSubjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD25770E1BA2C95A00BF7559 /* TestSubjects.swift */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
@@ -24,7 +24,7 @@
 		174DF0D5891FAF41A24E6525 /* Pods.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		45C6534C5D434B16A83A1119 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		7280D9993C983EC5823F78BA /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
-		BD25770A1BA2C72700BF7559 /* TestReflectable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestReflectable.swift; sourceTree = "<group>"; };
+		BD25770A1BA2C72700BF7559 /* TestInspectable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInspectable.swift; sourceTree = "<group>"; };
 		BD25770C1BA2C91E00BF7559 /* TestMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMappable.swift; sourceTree = "<group>"; };
 		BD25770E1BA2C95A00BF7559 /* TestSubjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSubjects.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -65,7 +65,7 @@
 			isa = PBXGroup;
 			children = (
 				146D72B01AB782920058798C /* Supporting Files */,
-				BD25770A1BA2C72700BF7559 /* TestReflectable.swift */,
+				BD25770A1BA2C72700BF7559 /* TestInspectable.swift */,
 				BD25770C1BA2C91E00BF7559 /* TestMappable.swift */,
 				BD25770E1BA2C95A00BF7559 /* TestSubjects.swift */,
 			);
@@ -237,7 +237,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BD25770F1BA2C95A00BF7559 /* TestSubjects.swift in Sources */,
-				BD25770B1BA2C72700BF7559 /* TestReflectable.swift in Sources */,
+				BD25770B1BA2C72700BF7559 /* TestInspectable.swift in Sources */,
 				BD25770D1BA2C91E00BF7559 /* TestMappable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Pod/Podfile.lock
+++ b/Pod/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Tailor (0.1.1)
+  - Tailor (0.1.2)
 
 DEPENDENCIES:
   - Tailor (from `../`)
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Tailor: bb8aa0648fcad41b30169c2ba6af61e23797be64
+  Tailor: b530751947cb29aac528f3d987c9634a91cfb230
 
 COCOAPODS: 0.39.0.beta.4

--- a/Pod/Tests/TestInspectable.swift
+++ b/Pod/Tests/TestInspectable.swift
@@ -1,9 +1,9 @@
 import XCTest
 import Tailor
 
-class TestReflectable: XCTestCase {
+class TestInspectable: XCTestCase {
 
-  func testReflectionOnClass() {
+  func testInspectableOnClass() {
     let firstName = "Taylor"
     let lastName = "Swift"
     let sex = Sex.Female
@@ -21,7 +21,7 @@ class TestReflectable: XCTestCase {
     XCTAssertEqual(sex, person.property("sex"))
   }
 
-  func testReflectionOnStruct() {
+  func testInspectableOnStruct() {
     let firstName = "Taylor"
     let lastName = "Swift"
     let sex = Sex.Female
@@ -37,5 +37,20 @@ class TestReflectable: XCTestCase {
     XCTAssertEqual(lastName, person.property("lastName"))
     XCTAssertEqual(sex, person.sex)
     XCTAssertEqual(sex, person.property("sex"))
+  }
+
+  func testNestedAttributes() {
+    let data: [String : AnyObject] = ["firstName" : "Taylor",
+      "lastName" : "Swift",
+      "sex": "female",
+      "birth_date": "2014-07-15"]
+
+    var parent = TestPersonStruct(data)
+    var clone = parent
+    clone.firstName += " + Clone"
+
+    parent.relatives.append(clone)
+
+    XCTAssertEqual(parent.property("relatives.0"), clone)
   }
 }

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -1,4 +1,5 @@
 infix operator <- {}
+
 public typealias JSONArray = [[String : AnyObject]]
 public typealias JSONDictionary = [String : AnyObject]
 
@@ -27,6 +28,21 @@ public extension Inspectable {
       .map({ $1 }).first!
 
     var result = value as? T
+
+    let tail = components.dropFirst()
+    if let indexString = tail.first,
+      index = Int(indexString) {
+        result = (value as! [T])[index]
+        
+        if tail.count > 1 {
+          guard let range = key.rangeOfString(indexString) else { return nil }
+          let key = key.substringFromIndex(range.startIndex.advancedBy(2))
+          return property(key, dictionary: result)
+        } else {
+          return result
+        }
+    }
+
     let type:_MirrorType = _reflect(value)
     if type.disposition == .Optional && type.count != 0 {
       let (_, some) = type[0]


### PR DESCRIPTION
You can now find nested attributes with the following syntax.

## Usage
```swift 
object.property("relatives.0")
```

## Test
```swift
   let data: [String : AnyObject] = ["firstName" : "Taylor",
      "lastName" : "Swift",
      "sex": "female",
      "birth_date": "2014-07-15"]

    var parent = TestPersonStruct(data)
    var clone = parent
    clone.firstName += " + Clone"

    parent.relatives.append(clone)

    XCTAssertEqual(parent.property("relatives.0"), clone)
```