### PR TITLE
Refactor relation mapping

### DIFF
--- a/Pod/Tests/TestMappable.swift
+++ b/Pod/Tests/TestMappable.swift
@@ -90,4 +90,20 @@ class TestMappable: XCTestCase {
     XCTAssertEqual(testStruct.relatives[0].firstName, "Mini")
     XCTAssertEqual(testStruct.relatives[1].firstName, "Mini-Mini")
   }
+
+  func testMapArrayOfObjects() {
+    var testStruct = TestPersonStruct([:])
+    let relatives: [[String : AnyObject]] = [
+      ["firstName" : "Mini",
+        "lastName" : "Swift",
+        "sex": "female",
+        "birth_date": "2014-07-17"],
+      ["firstName" : "Mini-Mini",
+        "lastName" : "Swift",
+        "sex": "female",
+        "birth_date": "2014-07-18"]]
+
+    testStruct.relatives <- relatives.relation()
+    XCTAssert(testStruct.relatives.count == 2)
+  }
 }

--- a/Pod/Tests/TestSubjects.swift
+++ b/Pod/Tests/TestSubjects.swift
@@ -38,7 +38,7 @@ class TestPersonClass: NSObject, Inspectable, Mappable {
   }
 }
 
-struct TestPersonStruct: Inspectable, Equatable {
+struct TestPersonStruct: Inspectable, Mappable, Equatable {
   var firstName: String = ""
   var lastName: String? = ""
   var sex: Sex?

--- a/Pod/Tests/TestSubjects.swift
+++ b/Pod/Tests/TestSubjects.swift
@@ -61,12 +61,7 @@ struct TestPersonStruct: Inspectable, Mappable, Equatable {
       return dateFormatter.dateFromString(value)
     }
 
-    relatives <- map.relation("relatives") { (objects: JSONArray?) -> [TestPersonStruct]? in
-      guard let objects = objects else { return self.relatives }
-      for object in objects { self.relatives.append(TestPersonStruct(object)) }
-      return self.relatives
-    }
-
+    relatives <- map.relation("relatives")
   }
 }
 

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -76,6 +76,18 @@ public extension Inspectable {
   public func values() -> [Any]  { return Mirror(reflecting: self).children.map { $1 } }
 }
 
+public extension Array {
+  func relation<T : Mappable>() -> [T]? {
+    var objects = [T]()
+    for dictionary in self {
+      guard let dictionary = dictionary as? JSONDictionary else { continue }
+      let object = T(dictionary)
+      objects.append(object)
+    }
+    return objects
+  }
+}
+
 public extension Dictionary {
 
   func property<T>(name: String) -> T? {

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -13,7 +13,7 @@ public func <- <T>(inout left: T, right: T?) {
 }
 
 public protocol Inspectable { }
-public protocol Mappable: class {
+public protocol Mappable {
   init(_ map: JSONDictionary)
 }
 

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -100,9 +100,14 @@ public extension Dictionary {
     return transform(value: value as? U)
   }
 
-  func relation<T, U>(name: String, transform: ((value: U?) -> T?)? = nil) -> T? {
+  func relation<T : Mappable>(name: String) -> [T]? {
     guard let key = name as? Key, value = self[key] else { return nil }
-    guard let transform = transform else { return value as? T }
-    return transform(value: self[key] as? U)
+    guard let array = value as? JSONArray else { return nil }
+    var objects = [T]()
+    for dictionary in array {
+      let object = T(dictionary)
+      objects.append(object)
+    }
+    return objects
   }
 }

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -105,8 +105,7 @@ public extension Dictionary {
     guard let array = value as? JSONArray else { return nil }
     var objects = [T]()
     for dictionary in array {
-      let object = T(dictionary)
-      objects.append(object)
+      objects.append(T(dictionary))
     }
     return objects
   }

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -95,9 +95,8 @@ public extension Dictionary {
     return value as? T
   }
 
-  func transform<T, U>(name: String, transform: ((value: U?) -> T?)? = nil) -> T? {
+  func transform<T, U>(name: String, transform: ((value: U?) -> T?)) -> T? {
     guard let value = self[name as! Key] else { return nil }
-    guard let transform = transform else { return value as? T }
     return transform(value: value as? U)
   }
 

--- a/Tailor.podspec
+++ b/Tailor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Tailor"
   s.summary          = "Tailor Swift"
-  s.version          = "0.1.2"
+  s.version          = "0.1.3"
   s.homepage         = "https://github.com/zenangst/Tailor"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
Mapping relations should be a whole lot simpler now.

## Before
```swift
relatives <- map.relation("relatives") { (objects: JSONArray?) -> [TestPersonStruct]? in
guard let objects = objects else { return self.relatives }
for object in objects { self.relatives.append(TestPersonStruct(object)) }
return self.relatives
```
## After
```swift
relatives <- map.relation("relatives")
```
