### PR TITLE
Feature new object mapping.

### DIFF
--- a/Pod/Tests/TestMappable.swift
+++ b/Pod/Tests/TestMappable.swift
@@ -16,10 +16,12 @@ class TestMappable: XCTestCase {
     expectedStruct.lastName = "Swift"
     expectedStruct.sex = .Female
     expectedStruct.birthDate = dateFormatter.dateFromString("2014-07-15")!
+    let expectedJob = Job(["name" : "Musician"])
 
     let testStruct = TestPersonStruct([
       "firstName" : "Taylor",
       "lastName" : "Swift",
+      "job" : ["name" : "Musician"],
       "sex": "female",
       "birth_date": "2014-07-15"
       ])
@@ -28,6 +30,7 @@ class TestMappable: XCTestCase {
     XCTAssertEqual(testStruct.lastName, expectedStruct.lastName)
     XCTAssertEqual(testStruct.sex, expectedStruct.sex)
     XCTAssertEqual(testStruct.birthDate, expectedStruct.birthDate)
+    XCTAssertEqual(testStruct.job?.name, expectedJob.name)
   }
 
   func testMappableClass() {

--- a/Pod/Tests/TestSubjects.swift
+++ b/Pod/Tests/TestSubjects.swift
@@ -7,6 +7,18 @@ enum Sex: String {
   case Female = "female"
 }
 
+struct Job: Mappable {
+  var name: String = ""
+  
+  init(_ map: JSONDictionary) {
+    name <- map.property("name")
+  }
+}
+
+func ==(lhs: Job, rhs: Job) -> Bool {
+  return lhs.name == rhs.name
+}
+
 class TestPersonClass: NSObject, Inspectable, Mappable {
 
   var firstName: String = ""
@@ -43,9 +55,10 @@ struct TestPersonStruct: Inspectable, Mappable, Equatable {
   var lastName: String? = ""
   var sex: Sex?
   var birthDate = NSDate(timeIntervalSince1970: 1)
+  var job: Job? = nil
   var relatives = [TestPersonStruct]()
 
-  init(_ map: [String : AnyObject]) {
+  init(_ map: JSONDictionary) {
     firstName <- map.property("firstName")
     lastName  <- map.property("lastName")
 

--- a/Pod/Tests/TestSubjects.swift
+++ b/Pod/Tests/TestSubjects.swift
@@ -75,6 +75,7 @@ struct TestPersonStruct: Inspectable, Mappable, Equatable {
     }
 
     relatives <- map.relation("relatives")
+    job <- map.object("job")
   }
 }
 

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -95,6 +95,12 @@ public extension Dictionary {
     return value as? T
   }
 
+  func object<T : Mappable>(name: String) -> T? {
+    guard let value = self[name as! Key] else { return nil }
+    guard let dictionary = value as? JSONDictionary else { return nil }
+    return T(dictionary)
+  }
+
   func transform<T, U>(name: String, transform: ((value: U?) -> T?)) -> T? {
     guard let value = self[name as! Key] else { return nil }
     return transform(value: value as? U)


### PR DESCRIPTION
This pull request introduces a new method; `.object(name: String)`.
It simply maps a `Mappable` object with a dictionary.

From here on end, we have the following method to use when mapping JSON to an object;

## Literals
```swift
string <- map.property("string")
```

## Objects
```swift
object <- map.object(["key" : "value"])
```

## Relations (Array of objects)
```swift
relations <- map.relation([["key" : "value"]])
```