### PR TITLE
Rename relation to objects

### DIFF
--- a/Pod/Podfile.lock
+++ b/Pod/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Tailor (0.1.2)
+  - Tailor (0.1.4)
 
 DEPENDENCIES:
   - Tailor (from `../`)
@@ -9,6 +9,6 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  Tailor: b530751947cb29aac528f3d987c9634a91cfb230
+  Tailor: de504df6a3109881552e22a3a2f1fae7f2e9abe3
 
 COCOAPODS: 0.39.0.beta.4

--- a/Pod/Tests/TestSubjects.swift
+++ b/Pod/Tests/TestSubjects.swift
@@ -74,7 +74,7 @@ struct TestPersonStruct: Inspectable, Mappable, Equatable {
       return dateFormatter.dateFromString(value)
     }
 
-    relatives <- map.relation("relatives")
+    relatives <- map.objects("relatives")
     job <- map.object("job")
   }
 }

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -95,18 +95,18 @@ public extension Dictionary {
     return value as? T
   }
 
+  func transform<T, U>(name: String, transform: ((value: U?) -> T?)) -> T? {
+    guard let value = self[name as! Key] else { return nil }
+    return transform(value: value as? U)
+  }
+
   func object<T : Mappable>(name: String) -> T? {
     guard let value = self[name as! Key] else { return nil }
     guard let dictionary = value as? JSONDictionary else { return nil }
     return T(dictionary)
   }
 
-  func transform<T, U>(name: String, transform: ((value: U?) -> T?)) -> T? {
-    guard let value = self[name as! Key] else { return nil }
-    return transform(value: value as? U)
-  }
-
-  func relation<T : Mappable>(name: String) -> [T]? {
+  func objects<T : Mappable>(name: String) -> [T]? {
     guard let key = name as? Key, value = self[key] else { return nil }
     guard let array = value as? JSONArray else { return nil }
     var objects = [T]()

--- a/Tailor.podspec
+++ b/Tailor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name             = "Tailor"
   s.summary          = "Tailor Swift"
-  s.version          = "0.1.4"
+  s.version          = "0.1.5"
   s.homepage         = "https://github.com/zenangst/Tailor"
   s.license          = 'MIT'
   s.author           = { "Christoffer Winterkvist" => "christoffer@winterkvist.com" }


### PR DESCRIPTION
Instead of using `.relation`, we will do `.objects`.