### PR TITLE
Feature <+ infix operator

### DIFF
--- a/Pod/Tests/TestMappable.swift
+++ b/Pod/Tests/TestMappable.swift
@@ -109,4 +109,20 @@ class TestMappable: XCTestCase {
     testStruct.relatives <- relatives.objects()
     XCTAssert(testStruct.relatives.count == 2)
   }
+
+  func testAppendingObjects() {
+    var testStruct = TestPersonStruct([:])
+    let relatives: [[String : AnyObject]] = [
+      ["firstName" : "Mini",
+        "lastName" : "Swift",
+        "sex": "female",
+        "birth_date": "2014-07-17"],
+      ["firstName" : "Mini-Mini",
+        "lastName" : "Swift",
+        "sex": "female",
+        "birth_date": "2014-07-18"]]
+
+    testStruct.relatives <+ relatives.objects()
+    XCTAssert(testStruct.relatives.count == 2)
+  }
 }

--- a/Pod/Tests/TestMappable.swift
+++ b/Pod/Tests/TestMappable.swift
@@ -125,4 +125,16 @@ class TestMappable: XCTestCase {
     testStruct.relatives <+ relatives.objects()
     XCTAssert(testStruct.relatives.count == 2)
   }
+
+  func testAppendingObject() {
+    var testStruct = TestPersonStruct([:])
+    let relatives: [String : AnyObject] = ["first" :
+      ["firstName" : "Mini",
+        "lastName" : "Swift",
+        "sex": "female",
+        "birth_date": "2014-07-17"]]
+
+    testStruct.relatives <+ relatives.object("first")
+    XCTAssert(testStruct.relatives.count == 1)
+  }
 }

--- a/Pod/Tests/TestSubjects.swift
+++ b/Pod/Tests/TestSubjects.swift
@@ -64,6 +64,7 @@ struct TestPersonStruct: Inspectable, Mappable, Equatable {
   var birthDate = NSDate(timeIntervalSince1970: 1)
   var job: Job? = nil
   var relatives = [TestPersonStruct]()
+  let children = [TestPersonStruct]()
 
   init(_ map: JSONDictionary) {
     firstName <- map.property("firstName")

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -18,6 +18,11 @@ public func <+ <T>(inout left: [T], right: [T]?) {
   left.appendContentsOf(right)
 }
 
+public func <+ <T>(inout left: [T], right: T?) {
+  guard let right = right else { return }
+  left.append(right)
+}
+
 public protocol Inspectable { }
 public protocol Mappable {
   init(_ map: JSONDictionary)

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -1,4 +1,5 @@
 infix operator <- {}
+infix operator <+ {}
 
 public typealias JSONArray = [[String : AnyObject]]
 public typealias JSONDictionary = [String : AnyObject]

--- a/Source/Tailor.swift
+++ b/Source/Tailor.swift
@@ -13,6 +13,11 @@ public func <- <T>(inout left: T, right: T?) {
   left = right
 }
 
+public func <+ <T>(inout left: [T], right: [T]?) {
+  guard let right = right else { return }
+  left.appendContentsOf(right)
+}
+
 public protocol Inspectable { }
 public protocol Mappable {
   init(_ map: JSONDictionary)


### PR DESCRIPTION
Tailor can now append object and objects to property lists that are declared as `let`.

## Usage for object
```swift
testStruct.relatives <+ relatives.object("first")
```

## Usage for objects
```swift
testStruct.relatives <+ relatives.objects()
```