### PR TITLE
Improve object lookup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: objective-c
 
 before_install:
 - brew update
-- brew install carthage
+#- brew install carthage
 - if brew outdated | grep -qx xctool; then brew upgrade xctool; fi
 - carthage update --platform iOS,Mac
 

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-github "Quick/Nimble" "v3.0.0"
-github "Quick/Quick" "v0.8.0"
-github "hyperoslo/Sugar" "c3becb3e8314190aa7c75f055aea6a33144cccc7"
+github "Quick/Nimble" "v3.1.0"
+github "Quick/Quick" "v0.9.1"
+github "hyperoslo/Sugar" "2aad0207e3c7ef4f26a87aed3a6fffc5dfa38162"

--- a/Playground-Mac.playground/Contents.swift
+++ b/Playground-Mac.playground/Contents.swift
@@ -6,10 +6,12 @@ import Tailor
 struct Person: Inspectable, Mappable, Equatable {
   var firstName: String = ""
   var lastName: String? = ""
+  var age: Int = 0
 
   init(_ map: [String : AnyObject]) {
     firstName <- map.property("firstName")
     lastName  <- map.property("lastName")
+    age       <- map.property("age")
   }
 }
 
@@ -17,6 +19,8 @@ func ==(lhs: Person, rhs: Person) -> Bool {
   return lhs.firstName == rhs.firstName && lhs.lastName == rhs.lastName
 }
 
-let taylor = Person(["firstName" : "Taylor", "lastName" : "Swift"])
-print(taylor.firstName)
-print(taylor.lastName)
+let taylor = Person(["firstName" : "Taylor", "lastName" : "Swift", "age" : 27])
+
+taylor.value("firstName", String.self)
+taylor.value("lastName", OptionalString.self)
+taylor.value("age", Int.self)

--- a/Playground-Mac.playground/Contents.swift
+++ b/Playground-Mac.playground/Contents.swift
@@ -21,6 +21,10 @@ func ==(lhs: Person, rhs: Person) -> Bool {
 
 let taylor = Person(["firstName" : "Taylor", "lastName" : "Swift", "age" : 27])
 
-taylor.value("firstName", String.self)
-taylor.value("lastName", OptionalString.self)
-taylor.value("age", Int.self)
+do {
+  let firstName: String = try taylor.value("firstName")
+  let lastName: String? = try taylor.value("lastName")
+  let age: Int = try taylor.value("age")
+} catch { print(error) }
+
+

--- a/Sources/Shared/Tailor.swift
+++ b/Sources/Shared/Tailor.swift
@@ -1,11 +1,6 @@
 import Foundation
 import Sugar
 
-public typealias OptionalString = Optional<String>
-public typealias OptionalInt = Optional<Int>
-public typealias OptionalFloat  = Optional<Float>
-public typealias OptionalDouble  = Optional<Double>
-
 infix operator <- {}
 infix operator <+ {}
 

--- a/Sources/Shared/Tailor.swift
+++ b/Sources/Shared/Tailor.swift
@@ -33,6 +33,18 @@ public protocol Mappable {
   init(_ map: JSONDictionary)
 }
 
+public extension Mappable {
+
+  public func value<T>(key: String, _ type: T.Type) -> T? {
+    let value = Mirror(reflecting: self)
+      .children
+      .filter { $0.0 == key }
+      .map { $1 }
+
+    return value.first as? T
+  }
+}
+
 public extension Inspectable {
 
   public func property<T>(key: String, dictionary: T? = nil) -> T? {

--- a/Sources/Shared/Tailor.swift
+++ b/Sources/Shared/Tailor.swift
@@ -33,18 +33,6 @@ public protocol Mappable {
   init(_ map: JSONDictionary)
 }
 
-public extension Mappable {
-
-  public func value<T>(key: String, _ type: T.Type) -> T? {
-    let value = Mirror(reflecting: self)
-      .children
-      .filter { $0.0 == key }
-      .map { $1 }
-
-    return value.first as? T
-  }
-}
-
 public extension Inspectable {
 
   public func property<T>(key: String, dictionary: T? = nil) -> T? {
@@ -102,6 +90,31 @@ public extension Inspectable {
 
   public func keys() -> [String] { return Mirror(reflecting: self).children.map { $0.0! } }
   public func values() -> [Any]  { return Mirror(reflecting: self).children.map { $1 } }
+}
+
+public enum MappableError: ErrorType {
+  case TypeError(message: String)
+}
+
+public enum Result<T, Error: ErrorType> {
+  case Success(T)
+  case Failure(Error)
+}
+
+public extension Mappable where Self : Inspectable {
+
+  public func value<T>(key: String) throws -> T {
+    let value = Mirror(reflecting: self)
+      .children
+      .filter { $0.label == key }
+      .map { $1 }.first
+
+    guard let objectValue = value as? T else {
+      throw MappableError.TypeError(message: "Tried to get value \(value!) for \(key) as \(T.self) when expecting \(types()[key]!)")
+    }
+
+    return objectValue
+  }
 }
 
 public extension Array {

--- a/Sources/Shared/Tailor.swift
+++ b/Sources/Shared/Tailor.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Sugar
 
+public typealias OptionalString = Optional<String>
+public typealias OptionalInt = Optional<Int>
+public typealias OptionalFloat  = Optional<Float>
+public typealias OptionalDouble  = Optional<Double>
+
 infix operator <- {}
 infix operator <+ {}
 

--- a/Tailor.xcodeproj/project.pbxproj
+++ b/Tailor.xcodeproj/project.pbxproj
@@ -377,7 +377,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks --platform Mac";
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
 		BD793D561C3FD00F002BBB5F /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -391,7 +391,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/local/bin/carthage copy-frameworks --platform iOS";
+			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
 		D5C629731C3A86E3007F7B7C /* Copy frameworks with Carthage */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Tailor.xcodeproj/xcshareddata/xcschemes/Tailor-Mac.xcscheme
+++ b/Tailor.xcodeproj/xcshareddata/xcschemes/Tailor-Mac.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Tailor.xcodeproj/xcshareddata/xcschemes/Tailor-iOS.xcscheme
+++ b/Tailor.xcodeproj/xcshareddata/xcschemes/Tailor-iOS.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -159,4 +159,18 @@ class TestMappable: XCTestCase {
     } catch {}
   }
 
+  func testValueLookupFailure() {
+    let personStruct = TestPersonStruct([
+      "firstName" : "Mini",
+      "lastName" : "Swift",
+      "sex": "female",
+      "birth_date": "2014-07-15"
+      ])
+
+    do {
+      let _: String? = try personStruct.value("firstName")
+    } catch {
+      XCTAssertNotNil(error)
+    }
+  }
 }

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -143,4 +143,20 @@ class TestMappable: XCTestCase {
     XCTAssert(testStruct.relatives.count == 2)
   }
 
+  func testValueLookupSuccess() {
+    let personStruct = TestPersonStruct([
+      "firstName" : "Mini",
+      "lastName" : "Swift",
+      "sex": "female",
+      "birth_date": "2014-07-15"
+      ])
+
+    do {
+      let firstName: String = try personStruct.value("firstName")
+      let lastName: String? = try personStruct.value("lastName")
+      XCTAssertEqual(firstName, "Mini")
+      XCTAssertEqual(lastName, "Swift")
+    } catch {}
+  }
+
 }

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -173,4 +173,5 @@ class TestMappable: XCTestCase {
       XCTAssertNotNil(error)
     }
   }
+
 }


### PR DESCRIPTION
This PR adds a new method on `Inspectable` objects.

It can be used to safely get values via key from any object that conforms to the `Inspectable` protocol.

### Example
```swift
do {
  let firstName: String = try taylor.value("firstName")
  let lastName: String? = try taylor.value("lastName")
  let age: Int = try taylor.value("age")
} catch { print(error) }
```

### Implementation
```swift
  public func value<T>(key: String) throws -> T {
    let value = Mirror(reflecting: self)
      .children
      .filter { $0.label == key }
      .map { $1 }.first

    guard let objectValue = value as? T else {
      throw MappableError.TypeError(message: "Tried to get value \(value!) for \(key) as \(T.self) when expecting \(types()[key]!)")
    }

    return objectValue
  }
```

The method `throws` to make sure that you are getting the correct value type back.

As an added bonus, the error message that the method throws should give you enough information to point you to the right direction of what when wrong when trying to get the value.

### Failure example
```swift
let age: String = try taylor.value("age")
```

Would render this error message:

```
TypeError("Tried to get value 27 for age as String when expecting Int")
```