### PR TITLE
Refactor and revert to old API setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ struct Person: Mappable {
   init(_ map: JSONDictionary) {
     firstName <- map.property("first_name")
     lastName  <- map.property("last_name")
-    spouse    <- map.property("spouse")
+    spouse    <- map.relation("spouse")
   }
 }
 
@@ -82,8 +82,8 @@ struct Person: Mappable {
   init(_ map: JSONDictionary) {
     firstName <- map.property("first_name")
     lastName  <- map.property("last_name")
-    spouse    <- map.property("spouse")
-    parents   <- map.properties("parents")
+    spouse    <- map.relation("spouse")
+    parents   <- map.relations("parents")
   }
 }
 
@@ -116,8 +116,8 @@ struct Person: Mappable {
   init(_ map: JSONDictionary) {
     firstName <- map.property("first_name")
     lastName  <- map.property("last_name")
-    spouse    <- map.property("spouse")
-    parents   <- map.properties("parents")
+    spouse    <- map.relation("spouse")
+    parents   <- map.relations("parents")
     birthDate <- map.transform("birth_date", transformer: { (value: String?) -> NSDate? in
       guard let value = value else { return nil }
       let dateFormatter = NSDateFormatter()

--- a/Sources/Shared/Extensions/Dictionary+Tailor.swift
+++ b/Sources/Shared/Extensions/Dictionary+Tailor.swift
@@ -38,4 +38,19 @@ public extension Dictionary {
 
     return array.map { T($0) }
   }
+
+  func directory<T : Mappable>(name: String) -> [String : T]? {
+    guard let key = name as? Key, value = self[key],
+      dictionary = value as? JSONDictionary
+      else { return nil }
+
+    var directory = [String : T]()
+
+    for (key, value) in dictionary {
+      guard let value = value as? JSONDictionary else { continue }
+      directory[key] = T(value)
+    }
+
+    return directory
+  }
 }

--- a/Sources/Shared/Extensions/Dictionary+Tailor.swift
+++ b/Sources/Shared/Extensions/Dictionary+Tailor.swift
@@ -10,12 +10,12 @@ public extension Dictionary {
     return value
   }
 
-  func property<T : Hashable>(name: String) -> T? {
+  func property<T>(name: String) -> T? {
     guard let key = name as? Key,
-      value = self[key]
+      value = self[key] as? T
       else { return nil }
 
-    return value as? T
+    return value
   }
 
   func transform<T, U>(name: String, transformer: ((value: U?) -> T?)) -> T? {
@@ -23,7 +23,7 @@ public extension Dictionary {
     return transformer(value: value as? U)
   }
 
-  func property<T : Mappable>(name: String) -> T? {
+  func relation<T : Mappable>(name: String) -> T? {
     guard let value = self[name as! Key],
       dictionary = value as? JSONDictionary
       else { return nil }
@@ -31,7 +31,7 @@ public extension Dictionary {
     return T(dictionary)
   }
 
-  func properties<T : Mappable>(name: String) -> [T]? {
+  func relations<T : Mappable>(name: String) -> [T]? {
     guard let key = name as? Key, value = self[key],
       array = value as? JSONArray
       else { return nil }

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -184,4 +184,41 @@ class TestMappable: XCTestCase {
       print(error)
     }
   }
+
+  func testMultipleTypes() {
+    let multiTypeStruct = MultipleTypeStruct(
+      [
+        "stringArray" : ["a", "b", "c"],
+        "stringDictionary" : ["a" : "a" , "b" : "b", "c" : "c"],
+        "boolProperty" : true,
+        "people" : [
+          [
+            "firstName" : "foo",
+            "lastName" : "Swift",
+            "sex": "female",
+            "birth_date": "2014-07-15"
+          ],
+          [
+            "firstName" : "bar",
+            "lastName" : "Swift",
+            "sex": "female",
+            "birth_date": "2014-07-15"
+          ]
+        ],
+        "peopleDictionary" : ["Mini" : [
+          "firstName" : "Mini",
+          "lastName" : "Swift",
+          "sex": "female",
+          "birth_date": "2014-07-15"
+          ]]
+      ]
+    )
+
+    XCTAssertEqual(multiTypeStruct.stringArray, ["a", "b", "c"])
+    XCTAssertEqual(multiTypeStruct.stringDictionary, ["a" : "a" , "b" : "b", "c" : "c"])
+    XCTAssertEqual(multiTypeStruct.boolProperty, true)
+    XCTAssertEqual(multiTypeStruct.people.first?.firstName, TestPersonStruct(["firstName" : "foo"]).firstName)
+    XCTAssertEqual(multiTypeStruct.peopleDictionary["Mini"]?.firstName, TestPersonStruct(["firstName" : "Mini"]).firstName)
+    XCTAssertEqual(multiTypeStruct.people[1].firstName, "bar")
+  }
 }

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -135,7 +135,7 @@ class TestMappable: XCTestCase {
         "sex": "female",
         "birth_date": "2014-07-17"]]
 
-    testStruct.relatives <+ relatives.property("first")
+    testStruct.relatives <+ relatives.relation("first")
     XCTAssert(testStruct.relatives.count == 1)
 
     let copy = testStruct

--- a/TailorTests/Shared/TestSubjects.swift
+++ b/TailorTests/Shared/TestSubjects.swift
@@ -93,6 +93,22 @@ struct TestImmutable: SafeMappable {
   }
 }
 
+struct MultipleTypeStruct : Mappable {
+  var stringArray = [String]()
+  var stringDictionary = [String : String]()
+  var boolProperty = false
+  var people = [TestPersonStruct]()
+  var peopleDictionary = [String : TestPersonStruct]()
+
+  init(_ map: JSONDictionary) {
+    stringArray <- map.property("stringArray")
+    stringDictionary <- map.property("stringDictionary")
+    boolProperty <- map.property("boolProperty")
+    people <- map.relations("people")
+    peopleDictionary <- map.directory("peopleDictionary")
+  }
+}
+
 func ==(lhs: TestPersonStruct, rhs: TestPersonStruct) -> Bool {
   return lhs.firstName == rhs.firstName && lhs.lastName == rhs.lastName
 }

--- a/TailorTests/Shared/TestSubjects.swift
+++ b/TailorTests/Shared/TestSubjects.swift
@@ -78,8 +78,8 @@ struct TestPersonStruct: Mappable, Equatable {
 
     birthDate <- map.transform("birth_date", transformer: dateTransformer)
 
-    relatives <- map.properties("relatives")
-    job <- map.property("job")
+    relatives <- map.relations("relatives")
+    job <- map.relation("job")
   }
 }
 


### PR DESCRIPTION
So the last adventure caused some issues which made some of the properties unmappable because it some of the function signatures got mixed up. This PR fixes that issue and renames two of the functions in the public API.

Mapping objects use `relation`, mapping multiple options is done with `relations`.

This also adds one new mapping functions called `directory` which is a dictionary with objects.