### PR TITLE
Add dictionary and array method to Dictionary and Array

### DIFF
--- a/Sources/Shared/Extensions/Array+Tailor.swift
+++ b/Sources/Shared/Extensions/Array+Tailor.swift
@@ -24,4 +24,26 @@ public extension Array {
 
     return objects
   }
+ 
+  /**
+   - Parameter name: The index
+   - Returns: A child dictionary at that index, otherwise it returns nil
+   */
+  func dictionary(index: Int) -> JSONDictionary? {
+    guard let value = self[index] as? JSONDictionary where index < self.count
+      else { return nil }
+    
+    return value
+  }
+ 
+  /**
+   - Parameter name: The index
+   - Returns: A child array at that index, otherwise it returns nil
+   */
+  func array(index: Int) -> JSONArray? {
+    guard let value = self[index] as? JSONArray where index < self.count
+      else { return nil }
+    
+    return value
+  }
 }

--- a/Sources/Shared/Extensions/Array+Tailor.swift
+++ b/Sources/Shared/Extensions/Array+Tailor.swift
@@ -30,7 +30,7 @@ public extension Array {
    - Returns: A child dictionary at that index, otherwise it returns nil
    */
   func dictionary(index: Int) -> JSONDictionary? {
-    guard let value = self[index] as? JSONDictionary where index < self.count
+    guard index < self.count, let value = self[index] as? JSONDictionary
       else { return nil }
     
     return value
@@ -41,7 +41,7 @@ public extension Array {
    - Returns: A child array at that index, otherwise it returns nil
    */
   func array(index: Int) -> JSONArray? {
-    guard let value = self[index] as? JSONArray where index < self.count
+    guard index < self.count, let value = self[index] as? JSONArray
       else { return nil }
     
     return value

--- a/Sources/Shared/Extensions/Dictionary+Tailor.swift
+++ b/Sources/Shared/Extensions/Dictionary+Tailor.swift
@@ -78,4 +78,28 @@ public extension Dictionary {
 
     return directory
   }
+  
+  /**
+   - Parameter name: The name of the key
+   - Returns: A child dictionary for that key, otherwise it returns nil
+   */
+  func dictionary(name: String) -> JSONDictionary? {
+    guard let key = name as? Key,
+      value = self[key] as? JSONDictionary
+      else { return nil }
+    
+    return value
+  }
+  
+  /**
+   - Parameter name: The name of the key
+   - Returns: A child array for that key, otherwise it returns nil
+   */
+  func array(name: String) -> JSONArray? {
+    guard let key = name as? Key,
+      value = self[key] as? JSONArray
+      else { return nil }
+    
+    return value
+  }
 }

--- a/Tailor.xcodeproj/project.pbxproj
+++ b/Tailor.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		BDC182671C3FE45000B54DD7 /* TestMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC182621C3FE45000B54DD7 /* TestMappable.swift */; };
 		BDC182681C3FE45000B54DD7 /* TestSubjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC182631C3FE45000B54DD7 /* TestSubjects.swift */; };
 		BDC182691C3FE45000B54DD7 /* TestSubjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC182631C3FE45000B54DD7 /* TestSubjects.swift */; };
+		D2E827DA1CAD25FA003151A6 /* TestAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E827D91CAD25FA003151A6 /* TestAccessible.swift */; };
+		D2E827DB1CAD25FA003151A6 /* TestAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E827D91CAD25FA003151A6 /* TestAccessible.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Tailor.framework */; };
 		D5C6294A1C3A7FAA007F7B7C /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Tailor.framework */; };
 		D5C629771C3A878E007F7B7C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629751C3A878E007F7B7C /* Quick.framework */; };
@@ -64,6 +66,7 @@
 		BDC182611C3FE45000B54DD7 /* TestInspectable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInspectable.swift; sourceTree = "<group>"; };
 		BDC182621C3FE45000B54DD7 /* TestMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMappable.swift; sourceTree = "<group>"; };
 		BDC182631C3FE45000B54DD7 /* TestSubjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSubjects.swift; sourceTree = "<group>"; };
+		D2E827D91CAD25FA003151A6 /* TestAccessible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAccessible.swift; sourceTree = "<group>"; };
 		D500FD121C3AAC8E00782D78 /* Playground-Mac.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-Mac.playground"; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Tailor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tailor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B2E8A91C3A780C00C0327D /* Tailor-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tailor-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -233,6 +236,7 @@
 				BDC182611C3FE45000B54DD7 /* TestInspectable.swift */,
 				BDC182621C3FE45000B54DD7 /* TestMappable.swift */,
 				BDC182631C3FE45000B54DD7 /* TestSubjects.swift */,
+				D2E827D91CAD25FA003151A6 /* TestAccessible.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -490,6 +494,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDC182681C3FE45000B54DD7 /* TestSubjects.swift in Sources */,
+				D2E827DA1CAD25FA003151A6 /* TestAccessible.swift in Sources */,
 				BDC182641C3FE45000B54DD7 /* TestInspectable.swift in Sources */,
 				BDC182661C3FE45000B54DD7 /* TestMappable.swift in Sources */,
 			);
@@ -513,6 +518,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				BDC182691C3FE45000B54DD7 /* TestSubjects.swift in Sources */,
+				D2E827DB1CAD25FA003151A6 /* TestAccessible.swift in Sources */,
 				BDC182651C3FE45000B54DD7 /* TestInspectable.swift in Sources */,
 				BDC182671C3FE45000B54DD7 /* TestMappable.swift in Sources */,
 			);

--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -1,0 +1,78 @@
+import XCTest
+import Tailor
+import Sugar
+
+struct Club {
+  var people: [Person] = []
+  
+  init(_ map: JSONDictionary) {
+    people <- map.dictionary("detail")?.relations("people")
+  }
+}
+
+struct Person: Mappable {
+  
+  var firstName: String? = ""
+  var lastName: String? = ""
+  
+  init(_ map: JSONDictionary) {
+    firstName <- map.property("first_name")
+    lastName  <- map.property("last_name")
+  }
+}
+
+class TestAccessible: XCTestCase {
+  func testAccessible() {
+    let json = [
+      "school": [
+        "name": "Hyper",
+        "clubs": [
+          [
+            "detail": [
+              "name": "DC",
+              "people": [
+                [
+                  "first_name": "Clark",
+                  "last_name": "Kent"
+                ],
+                [
+                  "first_name": "Bruce",
+                  "last_name": "Wayne"
+                ]
+              ]
+            ]
+          ],
+          [
+            "detail": [
+              "name": "Marvel",
+              "people": [
+                [
+                  "first_name": "Tony",
+                  "last_name": "Stark"
+                ],
+                [
+                  "first_name": "Bruce",
+                  "last_name": "Banner"
+                ]
+              ]
+            ]
+          ]
+        ]
+      ]
+    ]
+    
+    if let marvelClubJSON = json.dictionary("school")?.array("clubs")?.dictionary(1) {
+      let club = Club(marvelClubJSON)
+      
+      let tony = club.people[0]
+      
+      XCTAssertEqual(tony.firstName, "Tony")
+      XCTAssertEqual(tony.lastName, "Stark")
+     
+      let hulk = club.people[1]
+      
+      XCTAssertEqual(hulk.firstName, "Bruce")
+      XCTAssertEqual(hulk.lastName, "Banner")
+    }
+  }
+}


### PR DESCRIPTION
Add some syntactic sugar to access dictionary and array, useful when

- Need to only access some path inside dictionary or array

```swift
if let marvelClubJSON = json.dictionary("school")?.array("clubs")?.dictionary(1) {
      let club = Club(marvelClubJSON)
}
```

- When the map JSONDictionary contains unwanted structure

```swift
struct Club {
  var people: [Person] = []
  
  init(_ map: JSONDictionary) {
    people <- map.dictionary("detail")?.relations("people")
  }
}
```

Test added