### PR TITLE
Add PathAccessible for easy accessing through path with key and index

### DIFF
--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -1,0 +1,37 @@
+import Sugar
+
+public protocol PathAccessible {
+  func path(path: [SubscriptKind]) -> JSONDictionary?
+}
+
+public extension PathAccessible {
+  /**
+   - Parameter name: The array of path, can be index or key
+   - Returns: A child dictionary for that path, otherwise it returns nil
+   */
+  func path(path: [SubscriptKind]) -> JSONDictionary? {
+    var castedPath = path.dropFirst()
+    castedPath.append(.Key(""))
+
+    let pairs = zip(path, Array(castedPath))
+    var result: Any = self
+
+    for (kind, castedKind) in pairs {
+      switch (kind, castedKind) {
+      case (let .Key(name), .Key):
+        result = (result as? JSONDictionary)?.dictionary(name)
+      case (let .Key(name), .Index):
+        result = (result as? JSONDictionary)?.array(name)
+      case (let .Index(index), .Key):
+        result = (result as? JSONArray)?.dictionary(index)
+      case (let .Index(index), .Index):
+        result = (result as? JSONArray)?.array(index)
+      }
+    }
+
+    return result as? JSONDictionary
+  }
+}
+
+extension Dictionary: PathAccessible {}
+extension Array: PathAccessible {}

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -1,14 +1,21 @@
 import Sugar
 
 public protocol PathAccessible {
-  func path(path: [SubscriptKind]) -> JSONDictionary?
-}
 
-public extension PathAccessible {
   /**
    - Parameter name: The array of path, can be index or key
    - Returns: A child dictionary for that path, otherwise it returns nil
    */
+  func path(path: [SubscriptKind]) -> JSONDictionary?
+
+  /**
+   - Parameter name: The key path, separated by dot
+   - Returns: A child dictionary for that path, otherwise it returns nil
+   */
+  func path(keyPath: String) -> JSONDictionary?
+}
+
+public extension PathAccessible {
   func path(path: [SubscriptKind]) -> JSONDictionary? {
     var castedPath = path.dropFirst()
     castedPath.append(.Key(""))
@@ -30,6 +37,18 @@ public extension PathAccessible {
     }
 
     return result as? JSONDictionary
+  }
+
+  func path(keyPath: String) -> JSONDictionary? {
+    let kinds: [SubscriptKind] = keyPath.componentsSeparatedByString(".").map {
+      if let index = Int($0) {
+        return .Index(index)
+      } else {
+        return .Key($0)
+      }
+    }
+
+    return path(kinds)
   }
 }
 

--- a/Sources/Shared/Tailor.swift
+++ b/Sources/Shared/Tailor.swift
@@ -1,9 +1,13 @@
 import Foundation
 import Sugar
 
+// MARK: - Error
+
 public enum MappableError: ErrorType {
   case TypeError(message: String)
 }
+
+// MARK: - SubscriptKind
 
 public enum SubscriptKind {
   case Index(Int)

--- a/Sources/Shared/Tailor.swift
+++ b/Sources/Shared/Tailor.swift
@@ -4,3 +4,30 @@ import Sugar
 public enum MappableError: ErrorType {
   case TypeError(message: String)
 }
+
+public enum SubscriptKind {
+  case Index(Int)
+  case Key(String)
+}
+
+extension SubscriptKind: IntegerLiteralConvertible {
+  public init(integerLiteral value: IntegerLiteralType) {
+    self = .Index(value)
+  }
+}
+
+extension SubscriptKind: StringLiteralConvertible {
+  public typealias UnicodeScalarLiteralType = StringLiteralType
+  public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
+    self = .Key("\(value)")
+  }
+
+  public typealias ExtendedGraphemeClusterLiteralType = StringLiteralType
+  public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
+    self = .Key(value)
+  }
+
+  public init(stringLiteral value: StringLiteralType) {
+    self = .Key(value)
+  }
+}

--- a/Tailor.xcodeproj/project.pbxproj
+++ b/Tailor.xcodeproj/project.pbxproj
@@ -27,6 +27,8 @@
 		BDC182671C3FE45000B54DD7 /* TestMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC182621C3FE45000B54DD7 /* TestMappable.swift */; };
 		BDC182681C3FE45000B54DD7 /* TestSubjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC182631C3FE45000B54DD7 /* TestSubjects.swift */; };
 		BDC182691C3FE45000B54DD7 /* TestSubjects.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC182631C3FE45000B54DD7 /* TestSubjects.swift */; };
+		D22829E71CCA2ECF00466A1C /* PathAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22829E61CCA2ECF00466A1C /* PathAccessible.swift */; };
+		D22829E81CCA2ECF00466A1C /* PathAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22829E61CCA2ECF00466A1C /* PathAccessible.swift */; };
 		D2E827DA1CAD25FA003151A6 /* TestAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E827D91CAD25FA003151A6 /* TestAccessible.swift */; };
 		D2E827DB1CAD25FA003151A6 /* TestAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E827D91CAD25FA003151A6 /* TestAccessible.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Tailor.framework */; };
@@ -66,6 +68,7 @@
 		BDC182611C3FE45000B54DD7 /* TestInspectable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestInspectable.swift; sourceTree = "<group>"; };
 		BDC182621C3FE45000B54DD7 /* TestMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestMappable.swift; sourceTree = "<group>"; };
 		BDC182631C3FE45000B54DD7 /* TestSubjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSubjects.swift; sourceTree = "<group>"; };
+		D22829E61CCA2ECF00466A1C /* PathAccessible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathAccessible.swift; sourceTree = "<group>"; };
 		D2E827D91CAD25FA003151A6 /* TestAccessible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAccessible.swift; sourceTree = "<group>"; };
 		D500FD121C3AAC8E00782D78 /* Playground-Mac.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-Mac.playground"; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Tailor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tailor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -144,6 +147,7 @@
 			children = (
 				BD81A14D1C73A644009955E3 /* Mappable.swift */,
 				BD81A1501C73A66D009955E3 /* SafeMappable.swift */,
+				D22829E61CCA2ECF00466A1C /* PathAccessible.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -486,6 +490,7 @@
 				BD81A1421C73A493009955E3 /* Dictionary+Tailor.swift in Sources */,
 				BD81A1511C73A66D009955E3 /* SafeMappable.swift in Sources */,
 				BD793D481C3FCC97002BBB5F /* Tailor.swift in Sources */,
+				D22829E71CCA2ECF00466A1C /* PathAccessible.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -510,6 +515,7 @@
 				BD81A1431C73A493009955E3 /* Dictionary+Tailor.swift in Sources */,
 				BD81A1521C73A66D009955E3 /* SafeMappable.swift in Sources */,
 				BD793D551C3FCFA2002BBB5F /* Tailor.swift in Sources */,
+				D22829E81CCA2ECF00466A1C /* PathAccessible.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -291,7 +291,11 @@ class TestMappable: XCTestCase {
                 "secret": "secret"
               ]
             ],
-            "dark": ">\"<"
+            "dark": ">\"<",
+            "identity": [
+              "day": "security",
+              "night": "hacker"
+            ]
           ]
         ]
       ]
@@ -301,11 +305,13 @@ class TestMappable: XCTestCase {
       var name: String = ""
       var trueName: String = ""
       var secret: String = ""
+      var identity: String = ""
 
       init(_ map: JSONDictionary) {
         self.name <- map.path(["info"])?.property("name")
         self.trueName <- map.path(["info", "true_info"])?.property("true_name")
         self.secret <- map.path(["chaos", 1, "way", "light", 1])?.property("secret")
+        self.identity <- map.path("chaos.1.way.identity")?.property("night")
       }
     }
 
@@ -313,5 +319,6 @@ class TestMappable: XCTestCase {
     XCTAssertEqual(person.name, "Elliot Alderson")
     XCTAssertEqual(person.trueName, "Mr. Robot")
     XCTAssertEqual(person.secret, "secret")
+    XCTAssertEqual(person.identity, "hacker")
   }
 }

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -266,4 +266,52 @@ class TestMappable: XCTestCase {
     XCTAssertEqual(issue.state, State.Open)
     XCTAssertEqual(issue.priority, Priority.High)
   }
+
+  func testPath() {
+    let json = [
+      "info": [
+        "name": "Elliot Alderson",
+        "true_info": [
+          "true_name": "Mr. Robot"
+        ]
+      ],
+      "chaos": [
+        [
+          "$": "@",
+          "!": "&"
+        ],
+        [
+          "way": [
+            "light": [
+              [
+                "±": "§",
+                "_": "="
+              ],
+              [
+                "secret": "secret"
+              ]
+            ],
+            "dark": ">\"<"
+          ]
+        ]
+      ]
+    ]
+
+    struct Person: Mappable {
+      var name: String = ""
+      var trueName: String = ""
+      var secret: String = ""
+
+      init(_ map: JSONDictionary) {
+        self.name <- map.path(["info"])?.property("name")
+        self.trueName <- map.path(["info", "true_info"])?.property("true_name")
+        self.secret <- map.path(["chaos", 1, "way", "light", 1])?.property("secret")
+      }
+    }
+
+    let person = Person(json)
+    XCTAssertEqual(person.name, "Elliot Alderson")
+    XCTAssertEqual(person.trueName, "Mr. Robot")
+    XCTAssertEqual(person.secret, "secret")
+  }
 }


### PR DESCRIPTION
So that we can use it like

```swift
self.secret <- map.path(["chaos", 1, "way", "light", 1])?.property("secret")
```

Initially, I want to use variadic parameter instead of array, but it seems to not work with these `LiteralConvertible` https://github.com/onmyway133/issues/issues/133