### PR TITLE
Remove boilerplate

### DIFF
--- a/Sources/Shared/Extensions/Dictionary+Tailor.swift
+++ b/Sources/Shared/Extensions/Dictionary+Tailor.swift
@@ -45,8 +45,8 @@ public extension Dictionary {
    - Returns: A mappable object directory, otherwise it returns nil
    */
   func directory<T : Mappable>(name: String) -> [String : T]? {
-    guard let key = name as? Key, value = self[key],
-      dictionary = value as? JSONDictionary
+    guard let key = name as? Key,
+      dictionary = self[key] as? JSONDictionary
       else { return nil }
 
     var directory = [String : T]()
@@ -138,8 +138,8 @@ public extension Dictionary {
    - Returns: A mappable object, otherwise it returns nil
    */
   func relation<T : Mappable>(name: String) -> T? {
-    guard let value = self[name as! Key],
-      dictionary = value as? JSONDictionary
+    guard let key = name as? Key,
+      dictionary = self[key] as? JSONDictionary
       else { return nil }
 
     return T(dictionary)
@@ -161,8 +161,8 @@ public extension Dictionary {
    - Returns: A mappable object, otherwise it returns nil
    */
   func relation<T : SafeMappable>(name: String) -> T? {
-    guard let value = self[name as! Key],
-      dictionary = value as? JSONDictionary
+    guard let key = name as? Key,
+      dictionary = self[key] as? JSONDictionary
       else { return nil }
 
     let result: T?
@@ -197,8 +197,8 @@ public extension Dictionary {
    - Returns: A mappable object array, otherwise it returns nil
    */
   func relations<T : Mappable>(name: String) -> [T]? {
-    guard let key = name as? Key, value = self[key],
-      array = value as? JSONArray
+    guard let key = name as? Key,
+      array = self[key] as? JSONArray
       else { return nil }
 
     return array.map { T($0) }
@@ -220,8 +220,8 @@ public extension Dictionary {
    - Returns: A mappable object array, otherwise it returns nil
    */
   func relations<T : SafeMappable>(name: String) -> [T]? {
-    guard let key = name as? Key, value = self[key],
-      array = value as? JSONArray
+    guard let key = name as? Key,
+      array = self[key] as? JSONArray
       else { return nil }
 
     var result = [T]()
@@ -254,8 +254,8 @@ public extension Dictionary {
    - Returns: A mappable object, considering hierarchy, otherwise it returns nil
    */
   func relationHierarchically<T where T: Mappable, T: HierarchyType>(name: String) -> T? {
-    guard let value = self[name as! Key],
-      dictionary = value as? JSONDictionary
+    guard let key = name as? Key,
+      dictionary = self[key] as? JSONDictionary
       else { return nil }
 
     return T.cluster(dictionary) as? T
@@ -267,8 +267,7 @@ public extension Dictionary {
    */
   func relationsHierarchically<T where T: Mappable, T: HierarchyType>(name: String) -> [T]? {
     guard let key = name as? Key,
-      value = self[key],
-      array = value as? JSONArray
+      array = self[key] as? JSONArray
       else { return nil }
 
     return array.flatMap { T.cluster($0) as? T }

--- a/TailorTests/Shared/TestSubjects.swift
+++ b/TailorTests/Shared/TestSubjects.swift
@@ -48,11 +48,6 @@ class TestPersonClass: NSObject, Mappable {
       return dateFormatter.dateFromString(value)
     }
   }
-
-  func mapping(map: JSONDictionary) {
-    firstName <- map.property("firstName")
-    lastName  <- map.property("lastName")
-  }
 }
 
 struct TestPersonStruct: Mappable, Equatable {


### PR DESCRIPTION
- Use as? instead of as!
- Remove unneeded temporary variables