### PR TITLE
Support defaultValue

### DIFF
--- a/Sources/Shared/Operators/Operators.swift
+++ b/Sources/Shared/Operators/Operators.swift
@@ -1,7 +1,7 @@
 prefix operator <- {}
+prefix operator <? {}
 infix operator <- {}
 infix operator <+ {}
-prefix operator <? {}
 
 public prefix func <-<T>(rhs: T?) throws -> T {
   guard let rhs = rhs else {
@@ -12,6 +12,10 @@ public prefix func <-<T>(rhs: T?) throws -> T {
 
 public prefix func <-<T>(rhs: T) throws -> T {
   return rhs
+}
+
+public prefix func <? <T: DefaultType>(value: T?) -> T {
+  return value ?? T.defaultValue
 }
 
 public func <- <T>(inout left: T, right: T) {
@@ -32,8 +36,4 @@ public func <+ <T>(inout left: [T], right: [T]?) {
 public func <+ <T>(inout left: [T], right: T?) {
   guard let right = right else { return }
   left.append(right)
-}
-
-public prefix func <? <T: DefaultType>(value: T?) -> T {
-  return value ?? T.defaultValue
 }

--- a/Sources/Shared/Operators/Operators.swift
+++ b/Sources/Shared/Operators/Operators.swift
@@ -1,6 +1,7 @@
 prefix operator <- {}
 infix operator <- {}
 infix operator <+ {}
+prefix operator <? {}
 
 public prefix func <-<T>(rhs: T?) throws -> T {
   guard let rhs = rhs else {
@@ -31,4 +32,8 @@ public func <+ <T>(inout left: [T], right: [T]?) {
 public func <+ <T>(inout left: [T], right: T?) {
   guard let right = right else { return }
   left.append(right)
+}
+
+public prefix func <? <T: DefaultType>(value: T?) -> T {
+  return value ?? T.defaultValue
 }

--- a/Sources/Shared/Protocols/DefaultType.swift
+++ b/Sources/Shared/Protocols/DefaultType.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+/**
+ Anything that has default value
+*/
+public protocol DefaultType {
+  static var defaultValue: Self { get }
+}
+
+extension String: DefaultType {
+  public static var defaultValue: String {
+    return ""
+  }
+}
+
+extension Int: DefaultType {
+  public static var defaultValue: Int {
+    return 0
+  }
+}
+
+extension Float: DefaultType {
+  public static var defaultValue: Float {
+    return 0
+  }
+}
+
+extension Bool: DefaultType {
+  public static var defaultValue: Bool {
+    return false
+  }
+}
+
+extension Array: DefaultType {
+  public static var defaultValue: Array {
+    return []
+  }
+}
+
+extension Dictionary: DefaultType {
+  public static var defaultValue: Dictionary {
+    return [:]
+  }
+}

--- a/Tailor.xcodeproj/project.pbxproj
+++ b/Tailor.xcodeproj/project.pbxproj
@@ -35,6 +35,10 @@
 		D2F488771CCDFFC7005DD009 /* HierarchyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F488751CCDFFC7005DD009 /* HierarchyType.swift */; };
 		D2F488791CCE00F2005DD009 /* TestHierarchyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F488781CCE00F2005DD009 /* TestHierarchyType.swift */; };
 		D2F4887A1CCE00F2005DD009 /* TestHierarchyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F488781CCE00F2005DD009 /* TestHierarchyType.swift */; };
+		D2F4887C1CCE2885005DD009 /* DefaultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F4887B1CCE2885005DD009 /* DefaultType.swift */; };
+		D2F4887D1CCE2885005DD009 /* DefaultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F4887B1CCE2885005DD009 /* DefaultType.swift */; };
+		D2F4887F1CCE296A005DD009 /* TestDefaultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F4887E1CCE296A005DD009 /* TestDefaultType.swift */; };
+		D2F488801CCE296A005DD009 /* TestDefaultType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F4887E1CCE296A005DD009 /* TestDefaultType.swift */; };
 		D5B2E8AA1C3A780C00C0327D /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2E89F1C3A780C00C0327D /* Tailor.framework */; };
 		D5C6294A1C3A7FAA007F7B7C /* Tailor.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629401C3A7FAA007F7B7C /* Tailor.framework */; };
 		D5C629771C3A878E007F7B7C /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5C629751C3A878E007F7B7C /* Quick.framework */; };
@@ -76,6 +80,8 @@
 		D2E827D91CAD25FA003151A6 /* TestAccessible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAccessible.swift; sourceTree = "<group>"; };
 		D2F488751CCDFFC7005DD009 /* HierarchyType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HierarchyType.swift; sourceTree = "<group>"; };
 		D2F488781CCE00F2005DD009 /* TestHierarchyType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHierarchyType.swift; sourceTree = "<group>"; };
+		D2F4887B1CCE2885005DD009 /* DefaultType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultType.swift; sourceTree = "<group>"; };
+		D2F4887E1CCE296A005DD009 /* TestDefaultType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestDefaultType.swift; sourceTree = "<group>"; };
 		D500FD121C3AAC8E00782D78 /* Playground-Mac.playground */ = {isa = PBXFileReference; lastKnownFileType = file.playground; path = "Playground-Mac.playground"; sourceTree = "<group>"; };
 		D5B2E89F1C3A780C00C0327D /* Tailor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tailor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B2E8A91C3A780C00C0327D /* Tailor-iOS-Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Tailor-iOS-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -155,6 +161,7 @@
 				BD81A1501C73A66D009955E3 /* SafeMappable.swift */,
 				D22829E61CCA2ECF00466A1C /* PathAccessible.swift */,
 				D2F488751CCDFFC7005DD009 /* HierarchyType.swift */,
+				D2F4887B1CCE2885005DD009 /* DefaultType.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -249,6 +256,7 @@
 				BDC182631C3FE45000B54DD7 /* TestSubjects.swift */,
 				D2E827D91CAD25FA003151A6 /* TestAccessible.swift */,
 				D2F488781CCE00F2005DD009 /* TestHierarchyType.swift */,
+				D2F4887E1CCE296A005DD009 /* TestDefaultType.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -500,6 +508,7 @@
 				BD793D481C3FCC97002BBB5F /* Tailor.swift in Sources */,
 				D22829E71CCA2ECF00466A1C /* PathAccessible.swift in Sources */,
 				D2F488761CCDFFC7005DD009 /* HierarchyType.swift in Sources */,
+				D2F4887C1CCE2885005DD009 /* DefaultType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -512,6 +521,7 @@
 				BDC182641C3FE45000B54DD7 /* TestInspectable.swift in Sources */,
 				D2F488791CCE00F2005DD009 /* TestHierarchyType.swift in Sources */,
 				BDC182661C3FE45000B54DD7 /* TestMappable.swift in Sources */,
+				D2F4887F1CCE296A005DD009 /* TestDefaultType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -527,6 +537,7 @@
 				BD793D551C3FCFA2002BBB5F /* Tailor.swift in Sources */,
 				D22829E81CCA2ECF00466A1C /* PathAccessible.swift in Sources */,
 				D2F488771CCDFFC7005DD009 /* HierarchyType.swift in Sources */,
+				D2F4887D1CCE2885005DD009 /* DefaultType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -539,6 +550,7 @@
 				BDC182651C3FE45000B54DD7 /* TestInspectable.swift in Sources */,
 				D2F4887A1CCE00F2005DD009 /* TestHierarchyType.swift in Sources */,
 				BDC182671C3FE45000B54DD7 /* TestMappable.swift in Sources */,
+				D2F488801CCE296A005DD009 /* TestDefaultType.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TailorTests/Shared/TestDefaultType.swift
+++ b/TailorTests/Shared/TestDefaultType.swift
@@ -1,0 +1,38 @@
+import XCTest
+import Tailor
+import Sugar
+
+struct Book: Mappable {
+  let name: String
+  let pageCount: Int
+  let website: NSURL?
+
+  init(_ map: JSONDictionary) {
+    name = <?map.property("name")
+    pageCount = <?map.property("page_count")
+    website = map.transform("website_url", transformer: NSURL.init(string: ))
+  }
+}
+
+class TestDefaultType: XCTestCase {
+  func testOperator() {
+    let string = <?(nil as String?)
+    XCTAssertEqual(string, "")
+
+    let int = <?(nil as Int?)
+    XCTAssertEqual(int, 0)
+  }
+
+  func testDefaultType() {
+    let json = [
+      "name": "Advanced Swift",
+      "page_count": 400,
+      "website_url": "https://www.objc.io/books/advanced-swift/"
+    ]
+
+    let book = Book(json)
+    XCTAssertEqual(book.name, "Advanced Swift")
+    XCTAssertEqual(book.pageCount, 400)
+    XCTAssertEqual(book.website, NSURL(string: "https://www.objc.io/books/advanced-swift/"))
+  }
+}


### PR DESCRIPTION
There are cases that users just want `struct` with `let` declaration. Previously, we have to declare `var` for `<-` to work. This just uses simple assignment with default value

- Add DefaultType for type that has default value
- Add `<?` operator to fall back to default value

```swift
struct Book: Mappable {
  let name: String
  let pageCount: Int
  let website: NSURL?

  init(_ map: JSONDictionary) {
    name = <?map.property("name")
    pageCount = <?map.property("page_count")
    website = map.transform("website_url", transformer: NSURL.init(string: ))
  }
}
```