### PR TITLE
Add type information

### DIFF
--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -74,5 +74,12 @@ class TestAccessible: XCTestCase {
       XCTAssertEqual(hulk.firstName, "Bruce")
       XCTAssertEqual(hulk.lastName, "Banner")
     }
+
+    XCTAssertNotNil(json.path("school.clubs.0.detail"))
+    
+    XCTAssertEqual(json.path("school.clubs.0.detail")?.property("name"), "DC")
+    XCTAssertEqual(json.path("school.clubs.1.detail")?.property("name"), "Marvel")
+
+    XCTAssertEqual(json.path("school.clubs.0.detail.people.1")?.property("first_name"), "Bruce")
   }
 }

--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -23,7 +23,7 @@ struct Person: Mappable {
 
 class TestAccessible: XCTestCase {
   func testAccessible() {
-    let json = [
+    let json: [String: AnyObject] = [
       "school": [
         "name": "Hyper",
         "clubs": [


### PR DESCRIPTION
This adds type information to json in the test. It makes it build faster, and ensures it is of type `JSONDictionary`

This shows an example of the difference in the types

```swift
// Dictionary<String, AnyObject>
let json: [String: AnyObject] = [
   "key": "value"
]

// Dictionary<String, NSDictionary>
let json = [
   "key": "value"
]
```

This is also because `extension Dictionary: PathAccessible {}`, it would be great if only `JSONDictionary` can conform to `PathAccessible`