### PR TITLE
Improve resolving paths

### DIFF
--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -52,8 +52,10 @@ public extension PathAccessible {
     return resolve(kinds)
   }
 
-  private func extractKey(path: String) -> (key: String, keyPath: String) {
-    return (key: path.split(".").last!,
+  private func extractKey(path: String) -> (key: String, keyPath: String)? {
+    guard let lastSplit = path.split(".").last else { return nil }
+
+    return (key: lastSplit,
             keyPath: Array(path.split(".").dropLast()).joinWithSeparator("."))
   }
 
@@ -66,19 +68,19 @@ public extension PathAccessible {
   }
 
   func path(keyPath: String) -> String? {
-    let (key, keyPath) = extractKey(keyPath)
+    guard let (key, keyPath) = extractKey(keyPath) else { return nil }
     let result: JSONDictionary? = resolve(keyPath)
     return result?.property(key)
   }
 
   func path(keyPath: String) -> Int? {
-    let (key, keyPath) = extractKey(keyPath)
+    guard let (key, keyPath) = extractKey(keyPath) else { return nil }
     let result: JSONDictionary? = resolve(keyPath)
     return result?.property(key)
   }
 
   func path(keyPath: String) -> JSONArray? {
-    let (key, keyPath) = extractKey(keyPath)
+    guard let (key, keyPath) = extractKey(keyPath) else { return nil }
     let result: JSONDictionary? = resolve(keyPath)
     return result?.array(key)
   }

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -16,7 +16,8 @@ public protocol PathAccessible {
 }
 
 public extension PathAccessible {
-  func path(path: [SubscriptKind]) -> JSONDictionary? {
+
+  private func resolve<T>(path: [SubscriptKind]) -> T? {
     var castedPath = path.dropFirst()
     castedPath.append(.Key(""))
 
@@ -36,11 +37,11 @@ public extension PathAccessible {
       }
     }
 
-    return result as? JSONDictionary
+    return result as? T
   }
 
-  func path(keyPath: String) -> JSONDictionary? {
-    let kinds: [SubscriptKind] = keyPath.componentsSeparatedByString(".").map {
+  private func resolve<T>(path: String) -> T? {
+    let kinds: [SubscriptKind] = path.componentsSeparatedByString(".").map {
       if let index = Int($0) {
         return .Index(index)
       } else {
@@ -48,7 +49,38 @@ public extension PathAccessible {
       }
     }
 
-    return path(kinds)
+    return resolve(kinds)
+  }
+
+  private func extractKey(path: String) -> (key: String, keyPath: String) {
+    return (key: path.split(".").last!,
+            keyPath: Array(path.split(".").dropLast()).joinWithSeparator("."))
+  }
+
+  func path(path: [SubscriptKind]) -> JSONDictionary? {
+    return resolve(path)
+  }
+
+  func path(keyPath: String) -> JSONDictionary? {
+    return resolve(keyPath)
+  }
+
+  func path(keyPath: String) -> String? {
+    let (key, keyPath) = extractKey(keyPath)
+    let result: JSONDictionary? = resolve(keyPath)
+    return result?.property(key)
+  }
+
+  func path(keyPath: String) -> Int? {
+    let (key, keyPath) = extractKey(keyPath)
+    let result: JSONDictionary? = resolve(keyPath)
+    return result?.property(key)
+  }
+
+  func path(keyPath: String) -> JSONArray? {
+    let (key, keyPath) = extractKey(keyPath)
+    let result: JSONDictionary? = resolve(keyPath)
+    return result?.array(key)
   }
 }
 

--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -61,6 +61,18 @@ class TestAccessible: XCTestCase {
       ]
     ]
     
+    XCTAssertEqual(json.path("school.clubs.0.detail.name"), "DC")
+    XCTAssertEqual(json.path("school.clubs.0.detail.people.0.first_name"), "Clark")
+    XCTAssertEqual(json.path("school.clubs.0.detail.people")!, [
+      [
+        "first_name": "Clark",
+        "last_name": "Kent"
+      ],
+      [
+        "first_name": "Bruce",
+        "last_name": "Wayne"
+      ]
+      ])
     if let marvelClubJSON = json.dictionary("school")?.array("clubs")?.dictionary(1) {
       let club = Club(marvelClubJSON)
       

--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -4,17 +4,17 @@ import Sugar
 
 struct Club {
   var people: [Person] = []
-  
+
   init(_ map: JSONDictionary) {
     people <- map.dictionary("detail")?.relations("people")
   }
 }
 
 struct Person: Mappable {
-  
+
   var firstName: String? = ""
   var lastName: String? = ""
-  
+
   init(_ map: JSONDictionary) {
     firstName <- map.property("first_name")
     lastName  <- map.property("last_name")
@@ -23,7 +23,7 @@ struct Person: Mappable {
 
 class TestAccessible: XCTestCase {
   func testAccessible() {
-    let json = [
+    let json: [String : AnyObject] = [
       "school": [
         "name": "Hyper",
         "clubs": [
@@ -60,7 +60,7 @@ class TestAccessible: XCTestCase {
         ]
       ]
     ]
-    
+
     XCTAssertEqual(json.path("school.clubs.0.detail.name"), "DC")
     XCTAssertEqual(json.path("school.clubs.0.detail.people.0.first_name"), "Clark")
     XCTAssertEqual(json.path("school.clubs.0.detail.people")!, [
@@ -73,16 +73,17 @@ class TestAccessible: XCTestCase {
         "last_name": "Wayne"
       ]
       ])
+
     if let marvelClubJSON = json.dictionary("school")?.array("clubs")?.dictionary(1) {
       let club = Club(marvelClubJSON)
-      
+
       let tony = club.people[0]
-      
+
       XCTAssertEqual(tony.firstName, "Tony")
       XCTAssertEqual(tony.lastName, "Stark")
-     
+
       let hulk = club.people[1]
-      
+
       XCTAssertEqual(hulk.firstName, "Bruce")
       XCTAssertEqual(hulk.lastName, "Banner")
     }

--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -95,8 +95,6 @@ class TestAccessible: XCTestCase {
       XCTAssertEqual(hulk.lastName, "Banner")
     }
 
-    XCTAssertNotNil(json.path("school.clubs.0.detail"))
-
     XCTAssertEqual(json.path("school.clubs.0.detail")?.property("name"), "DC")
     XCTAssertEqual(json.path("school.clubs.1.detail")?.property("name"), "Marvel")
 

--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -33,11 +33,13 @@ class TestAccessible: XCTestCase {
               "people": [
                 [
                   "first_name": "Clark",
-                  "last_name": "Kent"
+                  "last_name": "Kent",
+                  "age" : 78
                 ],
                 [
                   "first_name": "Bruce",
-                  "last_name": "Wayne"
+                  "last_name": "Wayne",
+                  "age" : 77
                 ]
               ]
             ]
@@ -48,11 +50,13 @@ class TestAccessible: XCTestCase {
               "people": [
                 [
                   "first_name": "Tony",
-                  "last_name": "Stark"
+                  "last_name": "Stark",
+                  "age" : 53
                 ],
                 [
                   "first_name": "Bruce",
-                  "last_name": "Banner"
+                  "last_name": "Banner",
+                  "age" : 54
                 ]
               ]
             ]
@@ -63,14 +67,17 @@ class TestAccessible: XCTestCase {
 
     XCTAssertEqual(json.path("school.clubs.0.detail.name"), "DC")
     XCTAssertEqual(json.path("school.clubs.0.detail.people.0.first_name"), "Clark")
+    XCTAssertEqual(json.path("school.clubs.0.detail.people.0.age"), 78)
     XCTAssertEqual(json.path("school.clubs.0.detail.people")!, [
       [
         "first_name": "Clark",
-        "last_name": "Kent"
+        "last_name": "Kent",
+        "age" : 78
       ],
       [
         "first_name": "Bruce",
-        "last_name": "Wayne"
+        "last_name": "Wayne",
+        "age" : 77
       ]
       ])
 


### PR DESCRIPTION
This PR aims to improve the usability of resolving key paths.

With this pull request you can resolve nested paths like this;

```swift
XCTAssertEqual(json.path("school.clubs.0.detail.name"), "DC")
    XCTAssertEqual(json.path("school.clubs.0.detail.people.0.first_name"), "Clark")
    XCTAssertEqual(json.path("school.clubs.0.detail.people.0.age"), 78)
    XCTAssertEqual(json.path("school.clubs.0.detail.people")!, [
      [
        "first_name": "Clark",
        "last_name": "Kent",
        "age" : 78
      ],
      [
        "first_name": "Bruce",
        "last_name": "Wayne",
        "age" : 77
      ]
      ])
```

It can achieve this with the refactoring done in `PathAccessible` to introduce method overloading for the `path` method.