### PR TITLE
Improve/resolving paths part deux

### DIFF
--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -35,7 +35,7 @@ public extension PathAccessible {
   }
 
   private func internalResolve<T>(path: String) -> T? {
-    if !path.contains(".") {
+    guard path.contains(".") else {
       if let index = Int(path) {
         return [index] as? T
       } else {
@@ -60,7 +60,7 @@ public extension PathAccessible {
     return (key: lastSplit,
             keyPath: Array(path.split(".").dropLast()).joinWithSeparator("."))
   }
-  
+
   @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
   public func path(path: [SubscriptKind]) -> JSONDictionary? { return internalResolve(path) }
   @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -61,7 +61,7 @@ public extension PathAccessible {
    - Returns: A tuple with the first key and the remaining key path
    */
   private func extractKey(path: String) -> (key: String, keyPath: String)? {
-    guard let lastSplit = path.split(".").last else { return nil }
+    guard let lastSplit = path.split(".").last where path.contains(".") else { return nil }
 
     return (key: lastSplit,
             keyPath: Array(path.split(".").dropLast()).joinWithSeparator("."))
@@ -97,10 +97,11 @@ public extension PathAccessible {
    - Returns: An Optional String
    */
   func resolve(keyPath path: String) -> String? {
-    guard path.contains(".") else { return resolveSubscript(path) }
-    guard let (key, path) = extractKey(path) else { return nil }
+    guard let (key, keyPath) = extractKey(path) else {
+      return resolveSubscript(path)
+    }
 
-    let result: JSONDictionary? = internalResolve(path)
+    let result: JSONDictionary? = internalResolve(keyPath)
     return result?.property(key)
   }
 
@@ -111,10 +112,11 @@ public extension PathAccessible {
    - Returns: An Optional Int
    */
   func resolve(keyPath path: String) -> Int? {
-    guard path.contains(".") else { return resolveSubscript(path) }
-    guard let (key, path) = extractKey(path) else { return nil }
+    guard let (key, keyPath) = extractKey(path) else {
+      return resolveSubscript(path)
+    }
 
-    let result: JSONDictionary? = internalResolve(path)
+    let result: JSONDictionary? = internalResolve(keyPath)
     return result?.property(key)
   }
 
@@ -125,10 +127,11 @@ public extension PathAccessible {
   - Returns: An Optional [AnyObject]
   */
   func resolve(keyPath path: String) -> JSONArray? {
-    guard path.contains(".") else { return resolveSubscript(path) }
-    guard let (key, path) = extractKey(path) else { return nil }
+    guard let (key, keyPath) = extractKey(path) else {
+      return resolveSubscript(path)
+    }
 
-    let result: JSONDictionary? = internalResolve(path)
+    let result: JSONDictionary? = internalResolve(keyPath)
     return result?.array(key)
   }
 }

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -74,9 +74,6 @@ public extension PathAccessible {
   @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
   public func path(path: String) -> JSONDictionary? { return resolve(keyPath: path) }
 
-  func resolve(keyPath path: [SubscriptKind]) -> JSONDictionary? {
-    return internalResolve(path)
-  }
   /**
    Resolve key path to Dictionary
 

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -41,6 +41,15 @@ public extension PathAccessible {
   }
 
   private func resolve<T>(path: String) -> T? {
+  private func internalResolve<T>(path: String) -> T? {
+    if !path.contains(".") {
+      if let index = Int(path) {
+        return [index] as? T
+      } else {
+        return (self as? JSONDictionary)?[path] as? T
+      }
+    }
+
     let kinds: [SubscriptKind] = path.componentsSeparatedByString(".").map {
       if let index = Int($0) {
         return .Index(index)

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -3,12 +3,6 @@ import Sugar
 public protocol PathAccessible {
 
   /**
-   - Parameter name: The array of path, can be index or key
-   - Returns: A child dictionary for that path, otherwise it returns nil
-   */
-  func resolve(keyPath path: [SubscriptKind]) -> JSONDictionary?
-
-  /**
    - Parameter name: The key path, separated by dot
    - Returns: A child dictionary for that path, otherwise it returns nil
    */

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -34,15 +34,15 @@ public extension PathAccessible {
     return result as? T
   }
 
-  private func internalResolve<T>(path: String) -> T? {
-    guard path.contains(".") else {
-      if let index = Int(path) {
-        return [index] as? T
-      } else {
-        return (self as? JSONDictionary)?[path] as? T
-      }
+  private func resolveSubscript<T>(key: String) -> T? {
+    if let index = Int(key) {
+      return [index] as? T
+    } else {
+      return (self as? JSONDictionary)?[key] as? T
     }
+  }
 
+  private func internalResolve<T>(path: String) -> T? {
     let kinds: [SubscriptKind] = path.componentsSeparatedByString(".").map {
       if let index = Int($0) {
         return .Index(index)
@@ -97,7 +97,9 @@ public extension PathAccessible {
    - Returns: An Optional String
    */
   func resolve(keyPath path: String) -> String? {
+    guard path.contains(".") else { return resolveSubscript(path) }
     guard let (key, path) = extractKey(path) else { return nil }
+
     let result: JSONDictionary? = internalResolve(path)
     return result?.property(key)
   }
@@ -109,7 +111,9 @@ public extension PathAccessible {
    - Returns: An Optional Int
    */
   func resolve(keyPath path: String) -> Int? {
+    guard path.contains(".") else { return resolveSubscript(path) }
     guard let (key, path) = extractKey(path) else { return nil }
+
     let result: JSONDictionary? = internalResolve(path)
     return result?.property(key)
   }
@@ -121,7 +125,9 @@ public extension PathAccessible {
   - Returns: An Optional [AnyObject]
   */
   func resolve(keyPath path: String) -> JSONArray? {
+    guard path.contains(".") else { return resolveSubscript(path) }
     guard let (key, path) = extractKey(path) else { return nil }
+
     let result: JSONDictionary? = internalResolve(path)
     return result?.array(key)
   }

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -62,17 +62,17 @@ public extension PathAccessible {
   }
   
   @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
-  func path(path: [SubscriptKind]) -> JSONDictionary? { return internalResolve(path) }
+  public func path(path: [SubscriptKind]) -> JSONDictionary? { return internalResolve(path) }
   @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
-  func path<T>(path: String) -> T? { return resolve(keyPath: path) as? T }
+  public func path<T>(path: String) -> T? { return resolve(keyPath: path) as? T }
   @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
-  func path(path: String) -> String? { return resolve(keyPath: path) }
+  public func path(path: String) -> String? { return resolve(keyPath: path) }
   @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
-  func path(path: String) -> Int? { return resolve(keyPath: path) }
+  public func path(path: String) -> Int? { return resolve(keyPath: path) }
   @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
-  func path(path: String) -> JSONArray? { return resolve(keyPath: path) }
+  public func path(path: String) -> JSONArray? { return resolve(keyPath: path) }
   @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
-  func path(path: String) -> JSONDictionary? { return resolve(keyPath: path) }
+  public func path(path: String) -> JSONDictionary? { return resolve(keyPath: path) }
 
   func resolve(keyPath path: [SubscriptKind]) -> JSONDictionary? {
     return internalResolve(path)

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -77,23 +77,46 @@ public extension PathAccessible {
   func resolve(keyPath path: [SubscriptKind]) -> JSONDictionary? {
     return internalResolve(path)
   }
+  /**
+   Resolve key path to Dictionary
 
+   - Parameter path: A key path string
+   - Returns: An Optional [String : AnyObject]
+   */
   func resolve(keyPath path: String) -> JSONDictionary? {
     return internalResolve(path)
   }
 
+  /**
+   Resolve key path to String
+
+   - Parameter path: A key path string
+   - Returns: An Optional String
+   */
   func resolve(keyPath path: String) -> String? {
     guard let (key, path) = extractKey(path) else { return nil }
     let result: JSONDictionary? = internalResolve(path)
     return result?.property(key)
   }
 
+  /**
+   Resolve key path to Int
+
+   - Parameter path: A key path string
+   - Returns: An Optional Int
+   */
   func resolve(keyPath path: String) -> Int? {
     guard let (key, path) = extractKey(path) else { return nil }
     let result: JSONDictionary? = internalResolve(path)
     return result?.property(key)
   }
 
+  /**
+   Resolve key path to [AnyObject]
+
+  - Parameter path: A key path string
+  - Returns: An Optional [AnyObject]
+  */
   func resolve(keyPath path: String) -> JSONArray? {
     guard let (key, path) = extractKey(path) else { return nil }
     let result: JSONDictionary? = internalResolve(path)

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -54,6 +54,12 @@ public extension PathAccessible {
     return internalResolve(kinds)
   }
 
+  /**
+   Extract last key from key path
+
+   - Parameter path: A key path
+   - Returns: A tuple with the first key and the remaining key path
+   */
   private func extractKey(path: String) -> (key: String, keyPath: String)? {
     guard let lastSplit = path.split(".").last else { return nil }
 

--- a/Sources/Shared/Protocols/PathAccessible.swift
+++ b/Sources/Shared/Protocols/PathAccessible.swift
@@ -6,18 +6,18 @@ public protocol PathAccessible {
    - Parameter name: The array of path, can be index or key
    - Returns: A child dictionary for that path, otherwise it returns nil
    */
-  func path(path: [SubscriptKind]) -> JSONDictionary?
+  func resolve(keyPath path: [SubscriptKind]) -> JSONDictionary?
 
   /**
    - Parameter name: The key path, separated by dot
    - Returns: A child dictionary for that path, otherwise it returns nil
    */
-  func path(keyPath: String) -> JSONDictionary?
+  func resolve(keyPath path: String) -> JSONDictionary?
 }
 
 public extension PathAccessible {
 
-  private func resolve<T>(path: [SubscriptKind]) -> T? {
+  private func internalResolve<T>(path: [SubscriptKind]) -> T? {
     var castedPath = path.dropFirst()
     castedPath.append(.Key(""))
 
@@ -40,7 +40,6 @@ public extension PathAccessible {
     return result as? T
   }
 
-  private func resolve<T>(path: String) -> T? {
   private func internalResolve<T>(path: String) -> T? {
     if !path.contains(".") {
       if let index = Int(path) {
@@ -58,7 +57,7 @@ public extension PathAccessible {
       }
     }
 
-    return resolve(kinds)
+    return internalResolve(kinds)
   }
 
   private func extractKey(path: String) -> (key: String, keyPath: String)? {
@@ -67,30 +66,43 @@ public extension PathAccessible {
     return (key: lastSplit,
             keyPath: Array(path.split(".").dropLast()).joinWithSeparator("."))
   }
+  
+  @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
+  func path(path: [SubscriptKind]) -> JSONDictionary? { return internalResolve(path) }
+  @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
+  func path<T>(path: String) -> T? { return resolve(keyPath: path) as? T }
+  @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
+  func path(path: String) -> String? { return resolve(keyPath: path) }
+  @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
+  func path(path: String) -> Int? { return resolve(keyPath: path) }
+  @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
+  func path(path: String) -> JSONArray? { return resolve(keyPath: path) }
+  @available(*, deprecated=1.1.3, message="Use resolve(keyPath:)")
+  func path(path: String) -> JSONDictionary? { return resolve(keyPath: path) }
 
-  func path(path: [SubscriptKind]) -> JSONDictionary? {
-    return resolve(path)
+  func resolve(keyPath path: [SubscriptKind]) -> JSONDictionary? {
+    return internalResolve(path)
   }
 
-  func path(keyPath: String) -> JSONDictionary? {
-    return resolve(keyPath)
+  func resolve(keyPath path: String) -> JSONDictionary? {
+    return internalResolve(path)
   }
 
-  func path(keyPath: String) -> String? {
-    guard let (key, keyPath) = extractKey(keyPath) else { return nil }
-    let result: JSONDictionary? = resolve(keyPath)
+  func resolve(keyPath path: String) -> String? {
+    guard let (key, path) = extractKey(path) else { return nil }
+    let result: JSONDictionary? = internalResolve(path)
     return result?.property(key)
   }
 
-  func path(keyPath: String) -> Int? {
-    guard let (key, keyPath) = extractKey(keyPath) else { return nil }
-    let result: JSONDictionary? = resolve(keyPath)
+  func resolve(keyPath path: String) -> Int? {
+    guard let (key, path) = extractKey(path) else { return nil }
+    let result: JSONDictionary? = internalResolve(path)
     return result?.property(key)
   }
 
-  func path(keyPath: String) -> JSONArray? {
-    guard let (key, keyPath) = extractKey(keyPath) else { return nil }
-    let result: JSONDictionary? = resolve(keyPath)
+  func resolve(keyPath path: String) -> JSONArray? {
+    guard let (key, path) = extractKey(path) else { return nil }
+    let result: JSONDictionary? = internalResolve(path)
     return result?.array(key)
   }
 }

--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -65,10 +65,10 @@ class TestAccessible: XCTestCase {
       ]
     ]
 
-    XCTAssertEqual(json.path("school.clubs.0.detail.name"), "DC")
-    XCTAssertEqual(json.path("school.clubs.0.detail.people.0.first_name"), "Clark")
-    XCTAssertEqual(json.path("school.clubs.0.detail.people.0.age"), 78)
-    XCTAssertEqual(json.path("school.clubs.0.detail.people")!, [
+    XCTAssertEqual(json.resolve(keyPath: "school.clubs.0.detail.name"), "DC")
+    XCTAssertEqual(json.resolve(keyPath: "school.clubs.0.detail.people.0.first_name"), "Clark")
+    XCTAssertEqual(json.resolve(keyPath: "school.clubs.0.detail.people.0.age"), 78)
+    XCTAssertEqual(json.resolve(keyPath: "school.clubs.0.detail.people")!, [
       [
         "first_name": "Clark",
         "last_name": "Kent",
@@ -98,9 +98,9 @@ class TestAccessible: XCTestCase {
       XCTAssertEqual(hulk.lastName, "Banner")
     }
 
-    XCTAssertEqual(json.path("school.clubs.0.detail")?.property("name"), "DC")
-    XCTAssertEqual(json.path("school.clubs.1.detail")?.property("name"), "Marvel")
+    XCTAssertEqual(json.resolve(keyPath: "school.clubs.0.detail.name"), "DC")
+    XCTAssertEqual(json.resolve(keyPath: "school.clubs.1.detail.name"), "Marvel")
 
-    XCTAssertEqual(json.path("school.clubs.0.detail.people.1")?.property("first_name"), "Bruce")
+    XCTAssertEqual(json.resolve(keyPath: "school.clubs.0.detail.people.1.first_name"), "Bruce")
   }
 }

--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -81,6 +81,9 @@ class TestAccessible: XCTestCase {
       ]
       ])
 
+    let array: [String : AnyObject]? = json.resolve(keyPath: "school")
+    XCTAssertNotNil(array)
+
     if let marvelClubJSON = json.dictionary("school")?.array("clubs")?.dictionary(1) {
       let club = Club(marvelClubJSON)
 

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -308,9 +308,9 @@ class TestMappable: XCTestCase {
       var identity: String = ""
 
       init(_ map: JSONDictionary) {
-        self.name <- map.resolve(keyPath: ["info"])?.property("name")
-        self.trueName <- map.resolve(keyPath: ["info", "true_info"])?.property("true_name")
-        self.secret <- map.resolve(keyPath: ["chaos", 1, "way", "light", 1])?.property("secret")
+        self.name <- map.resolve(keyPath: "info")?.property("name")
+        self.trueName <- map.resolve(keyPath: "info.true_info")?.property("true_name")
+        self.secret <- map.resolve(keyPath: "chaos.1.way.light.1")?.property("secret")
         self.identity <- map.resolve(keyPath: "chaos.1.way.identity")?.property("night")
       }
     }

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -308,10 +308,10 @@ class TestMappable: XCTestCase {
       var identity: String = ""
 
       init(_ map: JSONDictionary) {
-        self.name <- map.path(["info"])?.property("name")
-        self.trueName <- map.path(["info", "true_info"])?.property("true_name")
-        self.secret <- map.path(["chaos", 1, "way", "light", 1])?.property("secret")
-        self.identity <- map.path("chaos.1.way.identity")?.property("night")
+        self.name <- map.resolve(keyPath: ["info"])?.property("name")
+        self.trueName <- map.resolve(keyPath: ["info", "true_info"])?.property("true_name")
+        self.secret <- map.resolve(keyPath: ["chaos", 1, "way", "light", 1])?.property("secret")
+        self.identity <- map.resolve(keyPath: "chaos.1.way.identity")?.property("night")
       }
     }
 


### PR DESCRIPTION
This PR aims to bring a unified and clear public API, now you can resolve keys and key paths using `resolve(keyPath:)`.

Instead of

```swift
json.path("school.clubs.1.detail")?.property("name")
```

You can now write;

```swift
json.resolve(keyPath: "school.clubs.1.detail.name")
```

`path` has been marked as deprecated.