### PR TITLE
Add test for mapping floats

### DIFF
--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -105,4 +105,23 @@ class TestAccessible: XCTestCase {
 
     XCTAssertEqual(json.resolve(keyPath: "school.clubs.0.detail.people.1.first_name"), "Bruce")
   }
+
+  func testMappingFloats() {
+    let json: [String : Any] = [
+      "values" : [
+        "cgfloat" : CGFloat(10.0),
+        "float" : Float(10.0),
+        "double" : Double(10.0),
+        "generic": 10.0
+      ]
+    ]
+
+    XCTAssertEqual(json.resolve(keyPath: "values.cgfloat"), CGFloat(10.0))
+    XCTAssertEqual(json.resolve(keyPath: "values.float"), Float(10.0))
+    XCTAssertEqual(json.resolve(keyPath: "values.double"), Double(10.0))
+    XCTAssertEqual(json.resolve(keyPath: "values.generic"), CGFloat(10.0))
+    XCTAssertEqual(json.resolve(keyPath: "values.generic"), 10.0)
+    XCTAssertEqual(json.resolve(keyPath: "values.generic"), Double(10.0))
+    XCTAssertEqual(json.resolve(keyPath: "values.generic"), CGFloat(10.0))
+  }
 }


### PR DESCRIPTION
We have had some small issues with mapping floats since we transitioned to Swift 3. This PR just improves the test coverage.