### PR TITLE
Improve/mapping default types

### DIFF
--- a/Sources/Shared/Extensions/Dictionary+Tailor.swift
+++ b/Sources/Shared/Extensions/Dictionary+Tailor.swift
@@ -7,6 +7,125 @@
 
 public extension Dictionary {
 
+  /// Map value using key into Double
+  ///
+  /// - Parameter name: The name of the key.
+  /// - Returns: An optional Double
+  func double(_ name: String) -> Double? {
+    if let value: Float = property(name) {
+      return Double(value)
+    }
+
+    if let value: Int = property(name) {
+      return Double(value)
+    }
+
+    if let value: String = property(name) {
+      return Double(value)
+    }
+
+    return property(name)
+  }
+
+  /// Map value using key to Float
+  ///
+  /// - Parameter name: The name of the key.
+  /// - Returns: An optional Float
+  func float(_ name: String) -> Float? {
+    if let value: Double = property(name) {
+      return Float(value)
+    }
+
+    if let value: Int = property(name) {
+      return Float(value)
+    }
+
+    if let value: String = property(name) {
+      return Float(value)
+    }
+
+    return property(name)
+  }
+
+  /// Map value using key to Int
+  ///
+  /// - Parameter name: The name of the key.
+  /// - Returns: An optional Int
+  func int(_ name: String) -> Int? {
+    if let value: Double = property(name) {
+      return Int(value)
+    }
+
+    if let value: Float = property(name) {
+      return Int(value)
+    }
+
+    if let value: String = property(name) {
+      if let firstCharacter = value.characters.first, value.characters.count > 1 {
+        return Int(String(firstCharacter))
+      }
+
+      return Int(value)
+    }
+
+    return property(name)
+  }
+
+  /// Map value using key to String
+  ///
+  /// - Parameter name: The name of the key.
+  /// - Returns: An optional String
+  func string(_ name: String) -> String? {
+    if let value: Float = property(name) {
+      return String(value)
+    }
+
+    if let value: Double = property(name) {
+      return String(value)
+    }
+
+    if let value: Int = property(name) {
+      return String(value)
+    }
+
+    return property(name)
+  }
+
+  /// A generic method that maps a value from a key to a specific type.
+  ///
+  /// - Parameters:
+  ///   - forKey: The key that holds the value that should be mapped.
+  ///   - ofType: The type that should be used for casting.
+  /// - Returns: An optional value of the inferred type.
+  func value<T>(forKey: String, ofType: T.Type) -> T? {
+    guard let key = forKey as? Key else {
+      return nil
+    }
+
+    guard let value = self[key] else {
+      return nil
+    }
+
+    if let value = value as? T {
+      return value
+    } else {
+      switch ofType {
+      case is Double.Type:
+        return double(forKey) as? T
+      case is Float.Type:
+        return float(forKey) as? T
+      case is String.Type:
+        return string(forKey) as? T
+      case is Int.Type:
+        return int(forKey) as? T
+      default:
+        assertionFailure("Unsupported type: \(ofType)")
+      }
+    }
+
+    return nil
+  }
+
   /**
    - Parameter name: The name of the property that you want to map
    - Returns: A generic type if casting succeeds, otherwise it returns nil

--- a/Sources/Shared/Protocols/DefaultType.swift
+++ b/Sources/Shared/Protocols/DefaultType.swift
@@ -17,6 +17,12 @@ extension Int: DefaultType {
   }
 }
 
+extension Double: DefaultType {
+  public static var defaultValue: Double {
+    return 0
+  }
+}
+
 extension Float: DefaultType {
   public static var defaultValue: Float {
     return 0

--- a/Sources/Shared/Protocols/Mappable.swift
+++ b/Sources/Shared/Protocols/Mappable.swift
@@ -15,7 +15,7 @@ public extension Mappable {
       .map { $1 }.first
 
     guard let objectValue = value as? T else {
-      throw MappableError.typeError(message: "Tried to get value \(value) for \(key) as \(T.self) when expecting \(types()[key])")
+      throw MappableError.typeError(message: "Tried to get value \(String(describing: value)) for \(key) as \(T.self) when expecting \(String(describing: types()[key]))")
     }
 
     return objectValue
@@ -63,7 +63,7 @@ public extension Mappable {
    - Returns: A key-value dictionary.
    */
   public func properties() -> [String : Any] {
-    var properties = [String : Any]()
+    var properties = [String: Any]()
 
     for tuple in Mirror(reflecting: self).children {
       guard let key = tuple.label else { continue }
@@ -77,7 +77,7 @@ public extension Mappable {
    - Returns: A string based dictionary.
    */
   public func types() -> [String : String] {
-    var types = [String : String]()
+    var types = [String: String]()
     for tuple in Mirror(reflecting: self).children {
       guard let key = tuple.label else { continue }
       types[key] = "\(Mirror(reflecting: tuple.value).subjectType)"

--- a/Tailor.xcodeproj/project.pbxproj
+++ b/Tailor.xcodeproj/project.pbxproj
@@ -24,6 +24,9 @@
 		BD81A14F1C73A644009955E3 /* Mappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD81A14D1C73A644009955E3 /* Mappable.swift */; };
 		BD81A1511C73A66D009955E3 /* SafeMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD81A1501C73A66D009955E3 /* SafeMappable.swift */; };
 		BD81A1521C73A66D009955E3 /* SafeMappable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD81A1501C73A66D009955E3 /* SafeMappable.swift */; };
+		BD820B2F1EC3DB9B00074DCB /* DefaultTypesMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD820B2E1EC3DB9B00074DCB /* DefaultTypesMappingTests.swift */; };
+		BD820B301EC3DB9B00074DCB /* DefaultTypesMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD820B2E1EC3DB9B00074DCB /* DefaultTypesMappingTests.swift */; };
+		BD820B311EC3DB9B00074DCB /* DefaultTypesMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD820B2E1EC3DB9B00074DCB /* DefaultTypesMappingTests.swift */; };
 		BD8B1EB61D93E36F000C3F53 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8B1EB51D93E36F000C3F53 /* String+Extensions.swift */; };
 		BD8B1EB71D93E36F000C3F53 /* String+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD8B1EB51D93E36F000C3F53 /* String+Extensions.swift */; };
 		BDA0DFD31D93F93A00D299BE /* Dictionary+Tailor.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD81A1411C73A493009955E3 /* Dictionary+Tailor.swift */; };
@@ -111,6 +114,7 @@
 		BD81A1471C73A4DF009955E3 /* Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
 		BD81A14D1C73A644009955E3 /* Mappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Mappable.swift; sourceTree = "<group>"; };
 		BD81A1501C73A66D009955E3 /* SafeMappable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SafeMappable.swift; sourceTree = "<group>"; };
+		BD820B2E1EC3DB9B00074DCB /* DefaultTypesMappingTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultTypesMappingTests.swift; sourceTree = "<group>"; };
 		BD8B1EB51D93E36F000C3F53 /* String+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "String+Extensions.swift"; sourceTree = "<group>"; };
 		BDA0DFCB1D93F91E00D299BE /* Tailor.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tailor.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		BDA0DFDE1D93F9C400D299BE /* Info-tvOS.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "Info-tvOS.plist"; sourceTree = "<group>"; };
@@ -348,6 +352,7 @@
 				D2E827D91CAD25FA003151A6 /* TestAccessible.swift */,
 				D2F488781CCE00F2005DD009 /* TestHierarchyType.swift */,
 				D2F4887E1CCE296A005DD009 /* TestDefaultType.swift */,
+				BD820B2E1EC3DB9B00074DCB /* DefaultTypesMappingTests.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -647,7 +652,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		205B134C9A06DF85F44ACC26 /* [CP] Check Pods Manifest.lock */ = {
@@ -662,7 +667,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		3957F435028F9D213834E968 /* [CP] Embed Pods Frameworks */ = {
@@ -752,7 +757,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		8715AF38C3AFD263463813B8 /* [CP] Copy Pods Resources */ = {
@@ -782,7 +787,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		BD892C121DF4BD1000EE2620 /* SwiftLint */ = {
@@ -839,7 +844,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		D22D861EE47D804FE4A2915E /* [CP] Check Pods Manifest.lock */ = {
@@ -854,7 +859,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run \'pod install\' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		F80327164DDDBC658B28C9A3 /* [CP] Copy Pods Resources */ = {
@@ -902,6 +907,7 @@
 				BDA0DFF21D93FA4800D299BE /* TestAccessible.swift in Sources */,
 				BDA0DFF31D93FA4800D299BE /* TestHierarchyType.swift in Sources */,
 				BDA0DFF41D93FA4800D299BE /* TestDefaultType.swift in Sources */,
+				BD820B311EC3DB9B00074DCB /* DefaultTypesMappingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -932,6 +938,7 @@
 				D2F488791CCE00F2005DD009 /* TestHierarchyType.swift in Sources */,
 				BDC182661C3FE45000B54DD7 /* TestMappable.swift in Sources */,
 				D2F4887F1CCE296A005DD009 /* TestDefaultType.swift in Sources */,
+				BD820B2F1EC3DB9B00074DCB /* DefaultTypesMappingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -962,6 +969,7 @@
 				D2F4887A1CCE00F2005DD009 /* TestHierarchyType.swift in Sources */,
 				BDC182671C3FE45000B54DD7 /* TestMappable.swift in Sources */,
 				D2F488801CCE296A005DD009 /* TestDefaultType.swift in Sources */,
+				BD820B301EC3DB9B00074DCB /* DefaultTypesMappingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TailorTests/Shared/DefaultTypesMappingTests.swift
+++ b/TailorTests/Shared/DefaultTypesMappingTests.swift
@@ -1,0 +1,68 @@
+import Tailor
+import Quick
+import Nimble
+
+class TestMappingDefaultTypes: QuickSpec {
+
+  override func spec() {
+
+    describe("mapping default types") {
+
+      let dictionary: [String: Any] = [
+        "name" : "Swedish Chef",
+        "int": 1,
+        "float": 2.5,
+        "string": "1.25",
+        "array" : [
+          "foo", "bar", "baz"
+        ]
+      ]
+
+      it("resolves the correct values") {
+
+        expect(dictionary.value(forKey: "name", ofType: Double.self)).to(beNil())
+        expect(dictionary.value(forKey: "name", ofType: Float.self)).to(beNil())
+        expect(dictionary.value(forKey: "name", ofType: Int.self)).to(beNil())
+        expect(dictionary.value(forKey: "name", ofType: String.self)).to(equal("Swedish Chef"))
+
+        expect(dictionary.value(forKey: "float", ofType: Float.self)).to(equal(2.5))
+        expect(dictionary.value(forKey: "float", ofType: Double.self)).to(equal(2.5))
+        expect(dictionary.value(forKey: "float", ofType: Int.self)).to(equal(2))
+        expect(dictionary.value(forKey: "float", ofType: String.self)).to(equal("2.5"))
+
+        expect(dictionary.value(forKey: "int", ofType: Float.self)).to(equal(1.0))
+        expect(dictionary.value(forKey: "int", ofType: Double.self)).to(equal(1.0))
+        expect(dictionary.value(forKey: "int", ofType: Int.self)).to(equal(1))
+        expect(dictionary.value(forKey: "int", ofType: String.self)).to(equal("1"))
+
+        expect(dictionary.value(forKey: "string", ofType: Float.self)).to(equal(1.25))
+        expect(dictionary.value(forKey: "string", ofType: Double.self)).to(equal(1.25))
+        expect(dictionary.value(forKey: "string", ofType: Int.self)).to(equal(1))
+        expect(dictionary.value(forKey: "string", ofType: String.self)).to(equal("1.25"))
+
+        expect(dictionary.string("string")).to(equal("1.25"))
+
+        expect(dictionary.float("name")).to(beNil())
+        expect(dictionary.double("name")).to(beNil())
+        expect(dictionary.int("name")).to(beNil())
+        expect(dictionary.string("name")).to(equal("Swedish Chef"))
+
+        expect(dictionary.float("float")).to(equal(2.5))
+        expect(dictionary.double("float")).to(equal(2.5))
+        expect(dictionary.int("float")).to(equal(2))
+        expect(dictionary.string("float")).to(equal("2.5"))
+
+        expect(dictionary.float("int")).to(equal(1))
+        expect(dictionary.double("int")).to(equal(1))
+        expect(dictionary.int("int")).to(equal(1))
+        expect(dictionary.string("int")).to(equal("1"))
+
+        expect(dictionary.float("string")).to(equal(1.25))
+        expect(dictionary.double("string")).to(equal(1.25))
+        expect(dictionary.int("string")).to(equal(1))
+        expect(dictionary.string("string")).to(equal("1.25"))
+
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds methods for mapping double, float, int and string. When mapping a type, if it cannot be resolved directly, it will now try to resolve it as the closest type available.

If you map a Float but get a Double, Tailor will try to make a Float out of the Double before returning.