### PR TITLE
Throw using optional

### DIFF
--- a/Sources/Shared/Extensions/Dictionary+Tailor.swift
+++ b/Sources/Shared/Extensions/Dictionary+Tailor.swift
@@ -171,17 +171,6 @@ public extension Dictionary {
 
   /**
    - Parameter name: The name of the property that you want to map
-   - Returns: A generic type if casting succeeds, otherwise it throws
-   */
-  func propertyOrThrow<T>(_ name: String) throws -> T {
-    guard let result: T = property(name)
-      else { throw MappableError.typeError(message: "Tried to get value for \(name) as \(T.self)") }
-
-    return result
-  }
-
-  /**
-   - Parameter name: The name of the property that you want to map
    - Parameter transformer: A transformation closure
    - Returns: A generic type if casting succeeds, otherwise it returns nil
    */
@@ -226,17 +215,6 @@ public extension Dictionary {
 
   /**
    - Parameter name: The name of the key
-   - Returns: A child dictionary for that key, otherwise it throws
-   */
-  func dictionaryOrThrow(_ name: String) throws -> [String : Any] {
-    guard let result = dictionary(name)
-      else { throw MappableError.typeError(message: "Tried to get value for \(name) as [String : Any]") }
-
-    return result
-  }
-
-  /**
-   - Parameter name: The name of the key
    - Returns: A child array for that key, otherwise it returns nil
    */
   func array(_ name: String) -> [[String : Any]]? {
@@ -249,17 +227,6 @@ public extension Dictionary {
 
   /**
    - Parameter name: The name of the key
-   - Returns: A child array for that key, otherwise it throws
-   */
-  func arrayOrThrow(_ name: String) throws -> [[String : Any]] {
-    guard let result = array(name)
-      else { throw MappableError.typeError(message: "Tried to get value for \(name) as [[String : Any]]") }
-
-    return result
-  }
-
-  /**
-   - Parameter name: The name of the key
    - Returns: An enum if casting succeeds, otherwise it returns nil
    */
   func `enum`<T: RawRepresentable>(_ name: String) -> T? {
@@ -268,17 +235,6 @@ public extension Dictionary {
       else { return nil }
 
     return T(rawValue: value)
-  }
-
-  /**
-   - Parameter name: The name of the key
-   - Returns: An enum if casting succeeds, otherwise it throws
-   */
-  func enumOrThrow<T: RawRepresentable>(_ name: String) throws -> T {
-    guard let result: T = `enum`(name)
-      else { throw MappableError.typeError(message: "Tried to get value for \(name) as enum") }
-
-    return result
   }
 }
 
@@ -300,17 +256,6 @@ public extension Dictionary {
 
   /**
    - Parameter name: The name of the property that you want to map
-   - Returns: A generic type if casting succeeds, otherwise it throws
-   */
-  func relationOrThrow<T: Mappable>(_ name: String) throws -> T {
-    guard let result: T = relation(name)
-      else { throw MappableError.typeError(message: "Tried to get value for \(name) as \(T.self)") }
-
-    return result
-  }
-
-  /**
-   - Parameter name: The name of the property that you want to map
    - Returns: A mappable object, otherwise it returns nil
    */
   func relation<T: SafeMappable>(_ name: String) -> T? {
@@ -325,17 +270,6 @@ public extension Dictionary {
     } catch {
       result = nil
     }
-
-    return result
-  }
-
-  /**
-   - Parameter name: The name of the property that you want to map
-   - Returns: A generic type if casting succeeds, otherwise it throws
-   */
-  func relationOrThrow<T: SafeMappable>(_ name: String) throws -> T {
-    guard let result: T = relation(name)
-      else { throw MappableError.typeError(message: "Tried to get value for \(name) as \(T.self)") }
 
     return result
   }
@@ -359,17 +293,6 @@ public extension Dictionary {
 
   /**
    - Parameter name: The name of the property that you want to map
-   - Returns: A mappable object array, otherwise it throws
-   */
-  func relationsOrThrow<T: Mappable>(_ name: String) throws -> [T] {
-    guard let result: [T] = relations(name)
-      else { throw MappableError.typeError(message: "Tried to get value for \(name) as \(T.self)") }
-
-    return result
-  }
-
-  /**
-   - Parameter name: The name of the property that you want to map
    - Returns: A mappable object array, otherwise it returns nil
    */
   func relations<T: SafeMappable>(_ name: String) -> [T]? {
@@ -382,17 +305,6 @@ public extension Dictionary {
     do {
       result = try array.map { try T($0) }
     } catch {}
-
-    return result
-  }
-
-  /**
-   - Parameter name: The name of the property that you want to map
-   - Returns: A mappable object array, otherwise it throws
-   */
-  func relationsOrThrow<T: SafeMappable>(_ name: String) throws -> [T] {
-    guard let result: [T] = relations(name)
-      else { throw MappableError.typeError(message: "Tried to get value for \(name) as \(T.self)") }
 
     return result
   }

--- a/Sources/Shared/Extensions/Optional+Extensions.swift
+++ b/Sources/Shared/Extensions/Optional+Extensions.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+public extension Optional {
+  /// Unwrap value or throw if there isn't
+  func unwrapOrThrow() throws -> Wrapped {
+    switch self {
+    case .some(let value):
+      return value
+    case .none:
+      throw MappableError.typeError(message: "Can't unwrap")
+    }
+  }
+}

--- a/Sources/Shared/Extensions/Optional+Extensions.swift
+++ b/Sources/Shared/Extensions/Optional+Extensions.swift
@@ -10,4 +10,11 @@ public extension Optional {
       throw MappableError.typeError(message: "Can't unwrap")
     }
   }
+
+  /// Perform an action if not nil
+  func performIfNotNil(block: (Wrapped) -> Void) {
+    if case .some(let value) = self {
+      block(value)
+    }
+  }
 }

--- a/Sources/Shared/Operators/Operators.swift
+++ b/Sources/Shared/Operators/Operators.swift
@@ -3,13 +3,6 @@ prefix operator <?
 infix operator <-
 infix operator <+
 
-public prefix func <- <T>(rhs: T?) throws -> T {
-  guard let rhs = rhs else {
-    throw MappableError.typeError(message: "Unable to unrwap value")
-  }
-  return rhs
-}
-
 public prefix func <- <T>(rhs: T) throws -> T {
   return rhs
 }

--- a/Sources/Shared/Operators/Operators.swift
+++ b/Sources/Shared/Operators/Operators.swift
@@ -1,11 +1,6 @@
 prefix operator <-
 prefix operator <?
 infix operator <-
-infix operator <+
-
-public prefix func <- <T>(rhs: T) throws -> T {
-  return rhs
-}
 
 public prefix func <? <T: DefaultType>(value: T?) -> T {
   return value ?? T.defaultValue
@@ -19,14 +14,4 @@ public func <- <T>(left: inout T, right: T?) {
   guard let right = right else { return }
 
   left = right
-}
-
-public func <+ <T>(left: inout [T], right: [T]?) {
-  guard let right = right else { return }
-  left.append(contentsOf: right)
-}
-
-public func <+ <T>(left: inout [T], right: T?) {
-  guard let right = right else { return }
-  left.append(right)
 }

--- a/Sources/Shared/Operators/Operators.swift
+++ b/Sources/Shared/Operators/Operators.swift
@@ -1,13 +1,8 @@
-prefix operator <-
 prefix operator <?
 infix operator <-
 
 public prefix func <? <T: DefaultType>(value: T?) -> T {
   return value ?? T.defaultValue
-}
-
-public func <- <T>(left: inout T, right: T) {
-  left = right
 }
 
 public func <- <T>(left: inout T, right: T?) {

--- a/Tailor.xcodeproj/project.pbxproj
+++ b/Tailor.xcodeproj/project.pbxproj
@@ -51,6 +51,9 @@
 		D22829E81CCA2ECF00466A1C /* PathAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D22829E61CCA2ECF00466A1C /* PathAccessible.swift */; };
 		D2E827DA1CAD25FA003151A6 /* TestAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E827D91CAD25FA003151A6 /* TestAccessible.swift */; };
 		D2E827DB1CAD25FA003151A6 /* TestAccessible.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E827D91CAD25FA003151A6 /* TestAccessible.swift */; };
+		D2EC3BB91F06745D00AF84F4 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EC3BB81F06745D00AF84F4 /* Optional+Extensions.swift */; };
+		D2EC3BBA1F06745D00AF84F4 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EC3BB81F06745D00AF84F4 /* Optional+Extensions.swift */; };
+		D2EC3BBB1F06745D00AF84F4 /* Optional+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2EC3BB81F06745D00AF84F4 /* Optional+Extensions.swift */; };
 		D2F488761CCDFFC7005DD009 /* HierarchyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F488751CCDFFC7005DD009 /* HierarchyType.swift */; };
 		D2F488771CCDFFC7005DD009 /* HierarchyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F488751CCDFFC7005DD009 /* HierarchyType.swift */; };
 		D2F488791CCE00F2005DD009 /* TestHierarchyType.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2F488781CCE00F2005DD009 /* TestHierarchyType.swift */; };
@@ -105,6 +108,7 @@
 		BDC182631C3FE45000B54DD7 /* TestSubjects.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestSubjects.swift; sourceTree = "<group>"; };
 		D22829E61CCA2ECF00466A1C /* PathAccessible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PathAccessible.swift; sourceTree = "<group>"; };
 		D2E827D91CAD25FA003151A6 /* TestAccessible.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestAccessible.swift; sourceTree = "<group>"; };
+		D2EC3BB81F06745D00AF84F4 /* Optional+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Optional+Extensions.swift"; sourceTree = "<group>"; };
 		D2F488751CCDFFC7005DD009 /* HierarchyType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HierarchyType.swift; sourceTree = "<group>"; };
 		D2F488781CCE00F2005DD009 /* TestHierarchyType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TestHierarchyType.swift; sourceTree = "<group>"; };
 		D2F4887B1CCE2885005DD009 /* DefaultType.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DefaultType.swift; sourceTree = "<group>"; };
@@ -175,6 +179,7 @@
 				BD81A1411C73A493009955E3 /* Dictionary+Tailor.swift */,
 				BD81A1441C73A49D009955E3 /* Array+Tailor.swift */,
 				BD8B1EB51D93E36F000C3F53 /* String+Extensions.swift */,
+				D2EC3BB81F06745D00AF84F4 /* Optional+Extensions.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -636,6 +641,7 @@
 				BDA0DFD81D93F93A00D299BE /* SafeMappable.swift in Sources */,
 				BDA0DFD91D93F93A00D299BE /* PathAccessible.swift in Sources */,
 				BDA0DFDA1D93F93A00D299BE /* HierarchyType.swift in Sources */,
+				D2EC3BBB1F06745D00AF84F4 /* Optional+Extensions.swift in Sources */,
 				BDA0DFDB1D93F93A00D299BE /* DefaultType.swift in Sources */,
 				BDA0DFDC1D93F93A00D299BE /* Tailor.swift in Sources */,
 			);
@@ -667,6 +673,7 @@
 				BD81A1511C73A66D009955E3 /* SafeMappable.swift in Sources */,
 				BD793D481C3FCC97002BBB5F /* Tailor.swift in Sources */,
 				D22829E71CCA2ECF00466A1C /* PathAccessible.swift in Sources */,
+				D2EC3BB91F06745D00AF84F4 /* Optional+Extensions.swift in Sources */,
 				D2F488761CCDFFC7005DD009 /* HierarchyType.swift in Sources */,
 				D2F4887C1CCE2885005DD009 /* DefaultType.swift in Sources */,
 			);
@@ -698,6 +705,7 @@
 				BD81A1521C73A66D009955E3 /* SafeMappable.swift in Sources */,
 				BD793D551C3FCFA2002BBB5F /* Tailor.swift in Sources */,
 				D22829E81CCA2ECF00466A1C /* PathAccessible.swift in Sources */,
+				D2EC3BBA1F06745D00AF84F4 /* Optional+Extensions.swift in Sources */,
 				D2F488771CCDFFC7005DD009 /* HierarchyType.swift in Sources */,
 				D2F4887D1CCE2885005DD009 /* DefaultType.swift in Sources */,
 			);

--- a/TailorTests/Shared/DefaultTypesMappingTests.swift
+++ b/TailorTests/Shared/DefaultTypesMappingTests.swift
@@ -68,9 +68,9 @@ class TestMappingDefaultTypes: QuickSpec {
         expect(dictionary.double("string")).to(equal(1.25))
         expect(dictionary.int("string")).to(equal(1))
         expect(dictionary.string("string")).to(equal("1.25"))
-
+        
         expect(dictionary.boolean("string_number_bool")).to(equal(true))
-
+        
       }
     }
   }

--- a/TailorTests/Shared/TestAccessible.swift
+++ b/TailorTests/Shared/TestAccessible.swift
@@ -22,171 +22,171 @@ struct Person: Mappable {
 }
 
 class TestAccessible: QuickSpec {
-    override func spec() {
-        describe("test accessible") {
-            var json: [String : Any]!
-            var expected: [[String : Any]]!
-            var result: [[String : Any]]!
-            var array: [String : Any]?
-            var marvelClubJSON: [String : Any]!
-            var club: Club!
-            var tony: Person!
-            var hulk: Person!
+  override func spec() {
+    describe("test accessible") {
+      var json: [String : Any]!
+      var expected: [[String : Any]]!
+      var result: [[String : Any]]!
+      var array: [String : Any]?
+      var marvelClubJSON: [String : Any]!
+      var club: Club!
+      var tony: Person!
+      var hulk: Person!
 
-            beforeEach {
-                json = [
-                    "school": [
-                        "name": "Hyper",
-                        "clubs": [
-                            [
-                                "detail": [
-                                    "name": "DC",
-                                    "people": [
-                                        [
-                                            "first_name": "Clark",
-                                            "last_name": "Kent",
-                                            "age" : 78
-                                        ],
-                                        [
-                                            "first_name": "Bruce",
-                                            "last_name": "Wayne",
-                                            "age" : 77
-                                        ]
-                                    ]
-                                ]
-                            ],
-                            [
-                                "detail": [
-                                    "name": "Marvel",
-                                    "people": [
-                                        [
-                                            "first_name": "Tony",
-                                            "last_name": "Stark",
-                                            "age" : 53
-                                        ],
-                                        [
-                                            "first_name": "Bruce",
-                                            "last_name": "Banner",
-                                            "age" : 54
-                                        ]
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                ]
-
-                expected =  [
+      beforeEach {
+        json = [
+          "school": [
+            "name": "Hyper",
+            "clubs": [
+              [
+                "detail": [
+                  "name": "DC",
+                  "people": [
                     [
-                        "first_name": "Clark",
-                        "last_name": "Kent",
-                        "age" : 78
+                      "first_name": "Clark",
+                      "last_name": "Kent",
+                      "age" : 78
                     ],
                     [
-                        "first_name": "Bruce",
-                        "last_name": "Wayne",
-                        "age" : 77
+                      "first_name": "Bruce",
+                      "last_name": "Wayne",
+                      "age" : 77
                     ]
+                  ]
                 ]
-
-                result = json.resolve(keyPath: "school.clubs.0.detail.people")!
-                array = json.resolve(keyPath: "school")
-                marvelClubJSON = json.dictionary("school")?.array("clubs")?.dictionary(1)
-                club = Club(marvelClubJSON)
-                tony = club.people[0]
-                hulk = club.people[1]
-            }
-
-            it("has the correct detail name") {
-                expect(json.resolve(keyPath: "school.clubs.0.detail.name")).to(equal("DC"))
-            }
-
-            it("has the correct first name") {
-                expect(json.resolve(keyPath: "school.clubs.0.detail.people.0.first_name")).to(equal("Clark"))
-            }
-
-            it("has the correct age") {
-                expect(json.resolve(keyPath: "school.clubs.0.detail.people.0.age")).to(equal(78))
-            }
-
-            it("Has the correct count") {
-                expect(expected.count).to(equal(result.count))
-            }
-
-            it("has a non nil array") {
-                expect(array).toNot(beNil())
-            }
-
-            it("has the right first name for iron man") {
-                expect(tony.firstName).to(equal("Tony"))
-            }
-
-            it("has the right last name for iron man") {
-                expect(tony.lastName).to(equal("Stark"))
-            }
-
-            it("has the right first name for hulk") {
-                expect(hulk.firstName).to(equal("Bruce"))
-            }
-
-            it("has the right last name for hulk") {
-                expect(hulk.lastName).to(equal("Banner"))
-            }
-
-            it("has the right school name for DC") {
-                expect(json.resolve(keyPath: "school.clubs.0.detail.name")).to(equal("DC"))
-            }
-
-            it("has the right school name for Marvel") {
-                expect(json.resolve(keyPath: "school.clubs.1.detail.name")).to(equal("Marvel"))
-            }
-
-            it("has the right first name through keypath for hulk") {
-                expect(json.resolve(keyPath: "school.clubs.0.detail.people.1.first_name")).to(equal("Bruce"))
-            }
-
-        }
-
-        describe("mapping floats") {
-            var json: [String : Any]!
-
-            beforeEach {
-                json = [
-                    "values" : [
-                        "cgfloat" : CGFloat(10.0),
-                        "float" : Float(10.0),
-                        "double" : Double(10.0),
-                        "generic": 10.0
+              ],
+              [
+                "detail": [
+                  "name": "Marvel",
+                  "people": [
+                    [
+                      "first_name": "Tony",
+                      "last_name": "Stark",
+                      "age" : 53
+                    ],
+                    [
+                      "first_name": "Bruce",
+                      "last_name": "Banner",
+                      "age" : 54
                     ]
+                  ]
                 ]
-            }
+              ]
+            ]
+          ]
+        ]
 
-            it("has the correct non-generic cgfloat value") {
-                expect(json.resolve(keyPath: "values.cgfloat")).to(equal(CGFloat(10.0)))
-            }
+        expected =  [
+          [
+            "first_name": "Clark",
+            "last_name": "Kent",
+            "age" : 78
+          ],
+          [
+            "first_name": "Bruce",
+            "last_name": "Wayne",
+            "age" : 77
+          ]
+        ]
 
-            it("has the correct non-generic float value") {
-                expect(json.resolve(keyPath: "values.float")).to(equal(Float(10.0)))
-            }
+        result = json.resolve(keyPath: "school.clubs.0.detail.people")!
+        array = json.resolve(keyPath: "school")
+        marvelClubJSON = json.dictionary("school")?.array("clubs")?.dictionary(1)
+        club = Club(marvelClubJSON)
+        tony = club.people[0]
+        hulk = club.people[1]
+      }
 
-            it("has the correct non-generic double value") {
-                expect(json.resolve(keyPath: "values.double")).to(equal(Double(10.0)))
-            }
+      it("has the correct detail name") {
+        expect(json.resolve(keyPath: "school.clubs.0.detail.name")).to(equal("DC"))
+      }
 
-            it("has the correct generic value") {
-                expect(json.resolve(keyPath: "values.generic")).to(equal(10.0))
-            }
+      it("has the correct first name") {
+        expect(json.resolve(keyPath: "school.clubs.0.detail.people.0.first_name")).to(equal("Clark"))
+      }
 
-            it("has the correct generic CGFloat value") {
-                expect(json.resolve(keyPath: "values.generic")).to(equal(CGFloat(10.0)))
-            }
+      it("has the correct age") {
+        expect(json.resolve(keyPath: "school.clubs.0.detail.people.0.age")).to(equal(78))
+      }
 
-            it("has the correct generic double value") {
-                expect(json.resolve(keyPath: "values.generic")).to(equal(Double(10.0)))
-            }
+      it("Has the correct count") {
+        expect(expected.count).to(equal(result.count))
+      }
 
-        }
+      it("has a non nil array") {
+        expect(array).toNot(beNil())
+      }
+
+      it("has the right first name for iron man") {
+        expect(tony.firstName).to(equal("Tony"))
+      }
+
+      it("has the right last name for iron man") {
+        expect(tony.lastName).to(equal("Stark"))
+      }
+
+      it("has the right first name for hulk") {
+        expect(hulk.firstName).to(equal("Bruce"))
+      }
+
+      it("has the right last name for hulk") {
+        expect(hulk.lastName).to(equal("Banner"))
+      }
+
+      it("has the right school name for DC") {
+        expect(json.resolve(keyPath: "school.clubs.0.detail.name")).to(equal("DC"))
+      }
+
+      it("has the right school name for Marvel") {
+        expect(json.resolve(keyPath: "school.clubs.1.detail.name")).to(equal("Marvel"))
+      }
+
+      it("has the right first name through keypath for hulk") {
+        expect(json.resolve(keyPath: "school.clubs.0.detail.people.1.first_name")).to(equal("Bruce"))
+      }
 
     }
+
+    describe("mapping floats") {
+      var json: [String : Any]!
+
+      beforeEach {
+        json = [
+          "values" : [
+            "cgfloat" : CGFloat(10.0),
+            "float" : Float(10.0),
+            "double" : Double(10.0),
+            "generic": 10.0
+          ]
+        ]
+      }
+
+      it("has the correct non-generic cgfloat value") {
+        expect(json.resolve(keyPath: "values.cgfloat")).to(equal(CGFloat(10.0)))
+      }
+
+      it("has the correct non-generic float value") {
+        expect(json.resolve(keyPath: "values.float")).to(equal(Float(10.0)))
+      }
+
+      it("has the correct non-generic double value") {
+        expect(json.resolve(keyPath: "values.double")).to(equal(Double(10.0)))
+      }
+
+      it("has the correct generic value") {
+        expect(json.resolve(keyPath: "values.generic")).to(equal(10.0))
+      }
+
+      it("has the correct generic CGFloat value") {
+        expect(json.resolve(keyPath: "values.generic")).to(equal(CGFloat(10.0)))
+      }
+
+      it("has the correct generic double value") {
+        expect(json.resolve(keyPath: "values.generic")).to(equal(Double(10.0)))
+      }
+
+    }
+
+  }
 
 }

--- a/TailorTests/Shared/TestDefaultType.swift
+++ b/TailorTests/Shared/TestDefaultType.swift
@@ -17,62 +17,62 @@ struct Book: Mappable {
 
 class TestDefaultType: QuickSpec {
 
-    override func spec() {
+  override func spec() {
 
-        describe("operator") {
+    describe("operator") {
 
-            context("string") {
-                var string: String!
+      context("string") {
+        var string: String!
 
-                beforeEach {
-                    string = <?(nil as String?)
-                }
-
-                it("is equal to empty string") {
-                    expect(string).to(equal(""))
-                }
-
-            }
-
-            context("int") {
-                var int: Int!
-
-                beforeEach {
-                    int = <?(nil as Int?)
-                }
-
-                it("is equal to 0") {
-                    expect(int).to(equal(0))
-                }
-
-            }
-
+        beforeEach {
+          string = <?(nil as String?)
         }
 
-        describe("default type") {
-            var json: [String : Any]!
-            var book: Book!
-
-            beforeEach {
-                json = [
-                    "name": "Advanced Swift",
-                    "page_count": 400,
-                    "website_url": "https://www.objc.io/books/advanced-swift/"
-                ]
-                book = Book(json)
-            }
-
-            it("has the correct name") {
-                expect(book.name).to(equal("Advanced Swift"))
-            }
-
-            it("has the correct page count") {
-                expect(book.pageCount).to(equal(400))
-            }
-
-            it("has the correct website") {
-                expect(book.website).to(equal(URL(string: "https://www.objc.io/books/advanced-swift/")))
-            }
+        it("is equal to empty string") {
+          expect(string).to(equal(""))
         }
+
+      }
+
+      context("int") {
+        var int: Int!
+
+        beforeEach {
+          int = <?(nil as Int?)
+        }
+
+        it("is equal to 0") {
+          expect(int).to(equal(0))
+        }
+
+      }
+
     }
+
+    describe("default type") {
+      var json: [String : Any]!
+      var book: Book!
+
+      beforeEach {
+        json = [
+          "name": "Advanced Swift",
+          "page_count": 400,
+          "website_url": "https://www.objc.io/books/advanced-swift/"
+        ]
+        book = Book(json)
+      }
+
+      it("has the correct name") {
+        expect(book.name).to(equal("Advanced Swift"))
+      }
+
+      it("has the correct page count") {
+        expect(book.pageCount).to(equal(400))
+      }
+
+      it("has the correct website") {
+        expect(book.website).to(equal(URL(string: "https://www.objc.io/books/advanced-swift/")))
+      }
+    }
+  }
 }

--- a/TailorTests/Shared/TestInspectable.swift
+++ b/TailorTests/Shared/TestInspectable.swift
@@ -4,121 +4,121 @@ import Nimble
 
 class TestInspectable: QuickSpec {
 
-    override func spec() {
+  override func spec() {
 
-        describe("inspectable") {
+    describe("inspectable") {
 
-            var firstName: String!
-            var lastName: String!
-            var sex: Sex!
+      var firstName: String!
+      var lastName: String!
+      var sex: Sex!
 
-            beforeEach {
-                firstName = "Taylor"
-                lastName = "Swift"
-                sex = Sex.Female
-            }
+      beforeEach {
+        firstName = "Taylor"
+        lastName = "Swift"
+        sex = Sex.Female
+      }
 
-            context("on class") {
+      context("on class") {
 
-                var person: TestPersonClass!
+        var person: TestPersonClass!
 
-                beforeEach {
-                    person = TestPersonClass()
-                    person.firstName = firstName
-                    person.lastName = lastName
-                    person.sex = sex
-                }
-
-                it("has the correct first name") {
-                    expect(firstName).to(equal(person.firstName))
-                }
-
-                it("has the correct first name property") {
-                    expect(firstName).to(equal(person.property("firstName")))
-                }
-
-                it("has the correct last name") {
-                    expect(lastName).to(equal(person.lastName))
-                }
-
-                it("has the correct last name property") {
-                    expect(lastName).to(equal(person.property("lastName")))
-                }
-
-                it("has the correct sex") {
-                    expect(sex).to(equal(person.sex))
-                }
-
-                it("has the correct sex property") {
-                    expect(sex).to(equal(person.property("sex")))
-                }
-
-            }
-
-            context("on struct") {
-
-                var person: TestPersonStruct!
-
-                beforeEach {
-                    person = TestPersonStruct([:])
-                    person.firstName = firstName
-                    person.lastName = lastName
-                    person.sex = sex
-                }
-
-
-                it("has the correct first name") {
-                    expect(firstName).to(equal(person.firstName))
-                }
-
-                it("has the correct first name property") {
-                    expect(firstName).to(equal(person.property("firstName")))
-                }
-
-                it("has the correct last name") {
-                    expect(lastName).to(equal(person.lastName))
-                }
-
-                it("has the correct last name property") {
-                    expect(lastName).to(equal(person.property("lastName")))
-                }
-
-                it("has the correct sex") {
-                    expect(sex).to(equal(person.sex))
-                }
-
-                it("has the correct sex property") {
-                    expect(sex).to(equal(person.property("sex")))
-                }
-
-            }
-
+        beforeEach {
+          person = TestPersonClass()
+          person.firstName = firstName
+          person.lastName = lastName
+          person.sex = sex
         }
 
-        describe("nested attributes") {
-            var data: [String : Any]!
-            var parent: TestPersonStruct!
-            var clone: TestPersonStruct!
-
-            beforeEach {
-                data = [
-                    "firstName" : "Taylor",
-                    "lastName" : "Swift",
-                    "sex": "female",
-                    "birth_date": "2014-07-15"
-                ]
-                parent = TestPersonStruct(data)
-                clone = parent
-                clone.firstName += " + Clone"
-                parent.relatives.append(clone)
-            }
-
-            it("references the correct relative") {
-                expect(parent.property("relatives.0")).to(equal(clone))
-            }
-
+        it("has the correct first name") {
+          expect(firstName).to(equal(person.firstName))
         }
 
+        it("has the correct first name property") {
+          expect(firstName).to(equal(person.property("firstName")))
+        }
+
+        it("has the correct last name") {
+          expect(lastName).to(equal(person.lastName))
+        }
+
+        it("has the correct last name property") {
+          expect(lastName).to(equal(person.property("lastName")))
+        }
+
+        it("has the correct sex") {
+          expect(sex).to(equal(person.sex))
+        }
+
+        it("has the correct sex property") {
+          expect(sex).to(equal(person.property("sex")))
+        }
+
+      }
+
+      context("on struct") {
+
+        var person: TestPersonStruct!
+
+        beforeEach {
+          person = TestPersonStruct([:])
+          person.firstName = firstName
+          person.lastName = lastName
+          person.sex = sex
+        }
+
+
+        it("has the correct first name") {
+          expect(firstName).to(equal(person.firstName))
+        }
+
+        it("has the correct first name property") {
+          expect(firstName).to(equal(person.property("firstName")))
+        }
+
+        it("has the correct last name") {
+          expect(lastName).to(equal(person.lastName))
+        }
+
+        it("has the correct last name property") {
+          expect(lastName).to(equal(person.property("lastName")))
+        }
+
+        it("has the correct sex") {
+          expect(sex).to(equal(person.sex))
+        }
+
+        it("has the correct sex property") {
+          expect(sex).to(equal(person.property("sex")))
+        }
+
+      }
 
     }
+
+    describe("nested attributes") {
+      var data: [String : Any]!
+      var parent: TestPersonStruct!
+      var clone: TestPersonStruct!
+
+      beforeEach {
+        data = [
+          "firstName" : "Taylor",
+          "lastName" : "Swift",
+          "sex": "female",
+          "birth_date": "2014-07-15"
+        ]
+        parent = TestPersonStruct(data)
+        clone = parent
+        clone.firstName += " + Clone"
+        parent.relatives.append(clone)
+      }
+
+      it("references the correct relative") {
+        expect(parent.property("relatives.0")).to(equal(clone))
+      }
+
+    }
+
+
+  }
 }

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -4,537 +4,537 @@ import Tailor
 
 class TestMappable: QuickSpec {
 
-    lazy var dateFormatter: DateFormatter = {
-        var dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd"
-
-        return dateFormatter
-    }()
-
-    override func spec() {
-
-        describe("mapping") {
-
-            context("struct") {
-                var expectedStruct: TestPersonStruct!
-                var expectedJob: Job!
-                var testStruct: TestPersonStruct!
-
-                beforeEach {
-                    expectedStruct = TestPersonStruct([:])
-                    expectedStruct.firstName = "Taylor"
-                    expectedStruct.lastName = "Swift"
-                    expectedStruct.sex = .Female
-                    expectedStruct.birthDate = self.dateFormatter.date(from: "2014-07-15")!
-                    expectedJob = Job(["name" : "Musician"])
-
-                    testStruct = TestPersonStruct(
-                        [
-                            "firstName" : "Taylor",
-                            "lastName" : "Swift",
-                            "job" : ["name" : "Musician"],
-                            "sex": "female",
-                            "birth_date": "2014-07-15"
-                        ]
-                    )
-
-                }
-
-                it("has the correct first name") {
-                    expect(testStruct.firstName).to(equal(expectedStruct.firstName))
-                }
-
-                it("has the correct last name") {
-                    expect(testStruct.lastName).to(equal(expectedStruct.lastName))
-                }
-
-                it("has the correct sex") {
-                    expect(testStruct.sex).to(equal(expectedStruct.sex))
-                }
-
-                it("has the correct birthdate") {
-                    expect(testStruct.birthDate).to(equal(expectedStruct.birthDate))
-                }
-
-                it("has the correct job name") {
-                    expect(testStruct.job?.name).to(equal(expectedJob.name))
-                }
-            }
-
-            context("class") {
-                var expectedClass: TestPersonClass!
-                var testClass: TestPersonClass!
-
-                beforeEach {
-                    expectedClass = TestPersonClass([:])
-                    expectedClass.firstName = "Taylor"
-                    expectedClass.lastName = "Swift"
-                    expectedClass.sex = .Female
-                    expectedClass.birthDate = self.dateFormatter.date(from: "2014-07-15")
-
-                    testClass = TestPersonClass(
-                        [
-                            "firstName" : "Taylor",
-                            "lastName" : "Swift",
-                            "sex": "female",
-                            "birth_date": "2014-07-15"
-                        ]
-                    )
-                }
-
-                it("has the correct first name") {
-                    expect(testClass.firstName).to(equal(expectedClass.firstName))
-                }
-
-                it("has the correct last name") {
-                    expect(testClass.lastName).to(equal(expectedClass.lastName))
-                }
-
-                it("has the correct sex") {
-                    expect(testClass.sex).to(equal(expectedClass.sex))
-                }
-
-                it("has the correct birthdate") {
-                    expect(testClass.birthDate).to(equal(expectedClass.birthDate))
-                }
-
-            }
-
-            context("relations") {
-                var relationStruct: TestPersonStruct!
-                var expectedStruct: TestPersonStruct!
-                var testStruct: TestPersonStruct!
-
-                beforeEach {
-                    relationStruct = TestPersonStruct(
-                        [
-                            "firstName" : "Mini" as AnyObject,
-                            "lastName" : "Swift" as AnyObject,
-                            "sex": "female" as AnyObject,
-                            "birth_date": "2014-07-15" as AnyObject
-                        ]
-                    )
-                    expectedStruct = TestPersonStruct([:])
-                    expectedStruct.firstName = "Taylor"
-                    expectedStruct.lastName = "Swift"
-                    expectedStruct.sex = .Female
-                    expectedStruct.birthDate = self.dateFormatter.date(from: "2014-07-15")!
-                    expectedStruct.relatives.append(relationStruct)
-
-                    testStruct = TestPersonStruct(
-                        [
-                            "firstName" : "Taylor" as AnyObject,
-                            "lastName" : "Swift" as AnyObject,
-                            "sex": "female" as AnyObject,
-                            "birth_date": "2014-07-15" as AnyObject,
-                            "relatives" : [
-                                [
-                                    "firstName" : "Mini",
-                                    "lastName" : "Swift",
-                                    "sex": "female",
-                                    "birth_date": "2014-07-17"
-                                ],
-                                [
-                                    "firstName" : "Mini-Mini",
-                                    "lastName" : "Swift",
-                                    "sex": "female",
-                                    "birth_date": "2014-07-18"
-                                ]
-                            ]
-                        ]
-                    )
-                }
-
-                it("has the correct fist name") {
-                    expect(testStruct.firstName).to(equal(expectedStruct.firstName))
-                }
-
-                it("has the correct last name") {
-                    expect(testStruct.lastName).to(equal(expectedStruct.lastName))
-                }
-
-                it("has the correct sex") {
-                    expect(testStruct.sex).to(equal(expectedStruct.sex))
-                }
-
-                it("has the correct birth date") {
-                    expect(testStruct.sex).to(equal(expectedStruct.sex))
-                }
-
-                it("has the correct number of relatives") {
-                    expect(testStruct.relatives.count).to(equal(2))
-                }
-
-                it("first relative is the relation struct") {
-                    expect(testStruct.relatives[0]).to(equal(relationStruct))
-                }
-
-                it("first relative has the correct name") {
-                    expect(testStruct.relatives[0].firstName).to(equal("Mini"))
-                }
-
-                it("second relative has the correct name") {
-                    expect(testStruct.relatives[1].firstName).to(equal("Mini-Mini"))
-                }
-
-            }
-
-            context("array of objects") {
-                var testStruct: TestPersonStruct!
-                var relatives: [[String : Any]]!
-
-                beforeEach {
-                    testStruct = TestPersonStruct([:])
-                    relatives = [
-                        [
-                            "firstName" : "Mini",
-                            "lastName" : "Swift",
-                            "sex": "female",
-                            "birth_date": "2014-07-17"
-                        ],
-                        [
-                            "firstName" : "Mini-Mini",
-                            "lastName" : "Swift",
-                            "sex": "female",
-                            "birth_date": "2014-07-18"
-                        ]
-                    ]
-                    testStruct.relatives <- relatives.objects()
-
-                }
-
-                it("has the correct number of relatives") {
-                    expect(testStruct.relatives.count).to(equal(2))
-                }
-
-            }
-
-            context("appending objects") {
-                var testStruct: TestPersonStruct!
-                var relatives: [[String : Any]]!
-
-                beforeEach {
-                    testStruct = TestPersonStruct([:])
-                    relatives =  [
-                        [
-                            "firstName" : "Mini",
-                            "lastName" : "Swift",
-                            "sex": "female",
-                            "birth_date": "2014-07-17"
-                        ],
-                        [
-                            "firstName" : "Mini-Mini",
-                            "lastName" : "Swift",
-                            "sex": "female",
-                            "birth_date": "2014-07-18"
-                        ]
-                    ]
-
-                    testStruct.relatives <+ relatives.objects()
-                }
-
-                it("has the correct relative count") {
-                    expect(testStruct.relatives.count).to(equal(2))
-                }
-
-            }
-
-            context("appending object") {
-
-                var testStruct: TestPersonStruct!
-                var relatives: [String : Any]!
-                var copy: TestPersonStruct!
-
-                beforeEach {
-                    testStruct = TestPersonStruct([:])
-                    relatives = [
-                        "first" : [
-                            "firstName" : "Mini",
-                            "lastName" : "Swift",
-                            "sex": "female",
-                            "birth_date": "2014-07-17"
-                        ]
-                    ]
-                    testStruct.relatives <+ relatives.relation("first")
-                    copy = testStruct
-                }
-
-                it("has one relative") {
-                    expect(testStruct.relatives.count).to(equal(1))
-                }
-
-                context("after appending copy") {
-                    beforeEach {
-                        testStruct.relatives <+ copy
-                    }
-
-                    it("has two relatives") {
-                        expect(testStruct.relatives.count).to(equal(2))
-                    }
-                }
-            }
-
-            describe("value lookup") {
-                var personStruct: TestPersonStruct!
-
-                beforeEach {
-                    personStruct = TestPersonStruct(
-                        [
-                            "firstName" : "Mini",
-                            "lastName" : "Swift",
-                            "sex": "female",
-                            "birth_date": "2014-07-15"
-                        ]
-                    )
-                }
-
-                context("value lookup success") {
-                    var firstName: String!
-                    var lastName: String!
-
-                    it("is successful") {
-                        do {
-                            firstName = try personStruct.value("firstName")
-                            lastName = try personStruct.value("lastName")
-                            expect(firstName).to(equal("Mini"))
-                            expect(lastName).to(equal("Swift"))
-                        } catch {}
-                    }
-                }
-
-                context("value lookup failure") {
-
-                    it("has a non-nil error") {
-                        expect { try personStruct.value("123") }.to(throwError()) 
-                    }
-
-                }
-
-            }
-
-            context("immutable object mapping") {
-
-                var immutableStruct: TestImmutable!
-                var expectedJob: Job!
-                beforeEach {
-                    immutableStruct = try! TestImmutable(
-                        [
-                            "firstName" : "foo",
-                            "lastName" : "bar",
-                            "job" : ["name" : "Musician"],
-                            "hobbies" : [["name" : "Musician"]]
-                        ]
-                    )
-                    expectedJob = Job(["name" : "Musician"])
-                }
-
-                it("has the correct first name") {
-                    expect(immutableStruct.firstName).to(equal("foo"))
-                }
-
-                it("has the correct last name") {
-                    expect(immutableStruct.lastName).to(equal("bar"))
-                }
-
-                it("has the correct job") {
-                    expect(immutableStruct.job.name).to(equal(expectedJob.name))
-                }
-
-                it("has the correct number of hobbies") {
-                    expect(immutableStruct.hobbies.count).to(equal(1))
-                }
-
-                it("has the correct hobby") {
-                    expect(immutableStruct.hobbies[0].name).to(equal(expectedJob.name))
-                }
-            }
-
-            context("Multiple types") {
-                var multiTypeStruct: MultipleTypeStruct!
-
-                beforeEach {
-                    multiTypeStruct = MultipleTypeStruct(
-                        [
-                            "stringArray" : ["a", "b", "c"],
-                            "stringDictionary" : ["a" : "a", "b" : "b", "c" : "c"],
-                            "boolProperty" : true,
-                            "people" : [
-                                [
-                                    "firstName" : "foo",
-                                    "lastName" : "Swift",
-                                    "sex": "female",
-                                    "birth_date": "2014-07-15"
-                                ],
-                                [
-                                    "firstName" : "bar",
-                                    "lastName" : "Swift",
-                                    "sex": "female",
-                                    "birth_date": "2014-07-15"
-                                ]
-                            ],
-                            "peopleDictionary" : ["Mini" : [
-                                "firstName" : "Mini",
-                                "lastName" : "Swift",
-                                "sex": "female",
-                                "birth_date": "2014-07-15"
-                                ]
-                            ]
-                        ]
-                    )
-                }
-
-                it("has the correct string array") {
-                    expect(multiTypeStruct.stringArray).to(equal(["a", "b", "c"]))
-                }
-
-                it("has the correct string dict") {
-                    expect(multiTypeStruct.stringDictionary).to(equal(["a" : "a", "b" : "b", "c" : "c"]))
-                }
-
-                it("has the correct bool property") {
-                    expect(multiTypeStruct.boolProperty).to(beTruthy())
-                }
-
-                it("has the correct first name") {
-                    expect(multiTypeStruct.people.first?.firstName).to(equal(TestPersonStruct(["firstName" : "foo"]).firstName))
-                }
-
-                it("has the correct people dict values") {
-                    expect(multiTypeStruct.peopleDictionary["Mini"]?.firstName).to(equal(TestPersonStruct(["firstName" : "Mini"]).firstName))
-                }
-
-                it("has the correct last name on person 2") {
-                    expect(multiTypeStruct.people[1].firstName).to(equal("bar"))
-                }
-
-            }
-
-            context("enumerations") {
-
-                enum State: String {
-                    case Open = "open"
-                    case Closed = "closed"
-                }
-
-                enum Priority: Int {
-                    case low = 0
-                    case medium = 1
-                    case high = 2
-                }
-
-                struct Issue: Mappable {
-                    var name: String = ""
-                    var state: State = .Closed
-                    var priority: Priority = .low
-
-                    init(_ map: [String : Any]) {
-                        self.name <- map.property("name")
-                        self.state <- map.`enum`("state")
-                        self.priority <- map.`enum`("priority")
-                    }
-                }
-
-                var json: [String: Any]!
-                var issue: Issue!
-
-                beforeEach {
-                    json = [
-                        "name": "Swift 3 support",
-                        "state": "open",
-                        "priority": 2
-                    ]
-                    issue = Issue(json as [String : Any])
-                }
-
-                it("has the correct issue name") {
-                    expect(issue.name).to(equal("Swift 3 support"))
-                }
-
-                it("Has the correct issue state") {
-                    expect(issue.state).to(equal(State.Open))
-                }
-
-                it("has the correct issue priority") {
-                    expect(issue.priority).to(equal(Priority.high))
-                }
-
-            }
-
-            context("Path") {
-
-                struct Person: Mappable {
-                    var name: String = ""
-                    var trueName: String = ""
-                    var secret: String = ""
-                    var identity: String = ""
-
-                    init(_ map: [String : Any]) {
-                        self.name <- map.resolve(keyPath: "info")?.property("name")
-                        self.trueName <- map.resolve(keyPath: "info.true_info")?.property("true_name")
-                        self.secret <- map.resolve(keyPath: "chaos.1.way.light.1")?.property("secret")
-                        self.identity <- map.resolve(keyPath: "chaos.1.way.identity")?.property("night")
-                    }
-                }
-
-
-                var json: [String: Any]!
-                var person: Person!
-
-                beforeEach {
-                    json = [
-                        "info": [
-                            "name": "Elliot Alderson",
-                            "true_info": [
-                                "true_name": "Mr. Robot"
-                            ]
-                        ],
-                        "chaos": [
-                            [
-                                "$": "@",
-                                "!": "&"
-                            ],
-                            [
-                                "way": [
-                                    "light": [
-                                        [
-                                            "±": "§",
-                                            "_": "="
-                                        ],
-                                        [
-                                            "secret": "secret"
-                                        ]
-                                    ],
-                                    "dark": ">\"<",
-                                    "identity": [
-                                        "day": "security",
-                                        "night": "hacker"
-                                    ]
-                                ]
-                            ]
-                        ]
-                    ]
-                    person = Person(json as [String : Any])
-                }
-
-                it("has the correct name") {
-                    expect(person.name).to(equal("Elliot Alderson"))
-                }
-
-                it("has the correct true name") {
-                    expect(person.trueName).to(equal("Mr. Robot"))
-                }
-
-                it("has the correct secret") {
-                    expect(person.secret).to(equal("secret"))
-                }
-
-                it("has the correct identity") {
-                    expect(person.identity).to(equal("hacker"))
-                }
-
-            }
+  lazy var dateFormatter: DateFormatter = {
+    var dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "yyyy-MM-dd"
+
+    return dateFormatter
+  }()
+
+  override func spec() {
+
+    describe("mapping") {
+
+      context("struct") {
+        var expectedStruct: TestPersonStruct!
+        var expectedJob: Job!
+        var testStruct: TestPersonStruct!
+
+        beforeEach {
+          expectedStruct = TestPersonStruct([:])
+          expectedStruct.firstName = "Taylor"
+          expectedStruct.lastName = "Swift"
+          expectedStruct.sex = .Female
+          expectedStruct.birthDate = self.dateFormatter.date(from: "2014-07-15")!
+          expectedJob = Job(["name" : "Musician"])
+
+          testStruct = TestPersonStruct(
+            [
+              "firstName" : "Taylor",
+              "lastName" : "Swift",
+              "job" : ["name" : "Musician"],
+              "sex": "female",
+              "birth_date": "2014-07-15"
+            ]
+          )
 
         }
+
+        it("has the correct first name") {
+          expect(testStruct.firstName).to(equal(expectedStruct.firstName))
+        }
+
+        it("has the correct last name") {
+          expect(testStruct.lastName).to(equal(expectedStruct.lastName))
+        }
+
+        it("has the correct sex") {
+          expect(testStruct.sex).to(equal(expectedStruct.sex))
+        }
+
+        it("has the correct birthdate") {
+          expect(testStruct.birthDate).to(equal(expectedStruct.birthDate))
+        }
+
+        it("has the correct job name") {
+          expect(testStruct.job?.name).to(equal(expectedJob.name))
+        }
+      }
+
+      context("class") {
+        var expectedClass: TestPersonClass!
+        var testClass: TestPersonClass!
+
+        beforeEach {
+          expectedClass = TestPersonClass([:])
+          expectedClass.firstName = "Taylor"
+          expectedClass.lastName = "Swift"
+          expectedClass.sex = .Female
+          expectedClass.birthDate = self.dateFormatter.date(from: "2014-07-15")
+
+          testClass = TestPersonClass(
+            [
+              "firstName" : "Taylor",
+              "lastName" : "Swift",
+              "sex": "female",
+              "birth_date": "2014-07-15"
+            ]
+          )
+        }
+
+        it("has the correct first name") {
+          expect(testClass.firstName).to(equal(expectedClass.firstName))
+        }
+
+        it("has the correct last name") {
+          expect(testClass.lastName).to(equal(expectedClass.lastName))
+        }
+
+        it("has the correct sex") {
+          expect(testClass.sex).to(equal(expectedClass.sex))
+        }
+
+        it("has the correct birthdate") {
+          expect(testClass.birthDate).to(equal(expectedClass.birthDate))
+        }
+
+      }
+
+      context("relations") {
+        var relationStruct: TestPersonStruct!
+        var expectedStruct: TestPersonStruct!
+        var testStruct: TestPersonStruct!
+
+        beforeEach {
+          relationStruct = TestPersonStruct(
+            [
+              "firstName" : "Mini" as AnyObject,
+              "lastName" : "Swift" as AnyObject,
+              "sex": "female" as AnyObject,
+              "birth_date": "2014-07-15" as AnyObject
+            ]
+          )
+          expectedStruct = TestPersonStruct([:])
+          expectedStruct.firstName = "Taylor"
+          expectedStruct.lastName = "Swift"
+          expectedStruct.sex = .Female
+          expectedStruct.birthDate = self.dateFormatter.date(from: "2014-07-15")!
+          expectedStruct.relatives.append(relationStruct)
+
+          testStruct = TestPersonStruct(
+            [
+              "firstName" : "Taylor" as AnyObject,
+              "lastName" : "Swift" as AnyObject,
+              "sex": "female" as AnyObject,
+              "birth_date": "2014-07-15" as AnyObject,
+              "relatives" : [
+                [
+                  "firstName" : "Mini",
+                  "lastName" : "Swift",
+                  "sex": "female",
+                  "birth_date": "2014-07-17"
+                ],
+                [
+                  "firstName" : "Mini-Mini",
+                  "lastName" : "Swift",
+                  "sex": "female",
+                  "birth_date": "2014-07-18"
+                ]
+              ]
+            ]
+          )
+        }
+
+        it("has the correct fist name") {
+          expect(testStruct.firstName).to(equal(expectedStruct.firstName))
+        }
+
+        it("has the correct last name") {
+          expect(testStruct.lastName).to(equal(expectedStruct.lastName))
+        }
+
+        it("has the correct sex") {
+          expect(testStruct.sex).to(equal(expectedStruct.sex))
+        }
+
+        it("has the correct birth date") {
+          expect(testStruct.sex).to(equal(expectedStruct.sex))
+        }
+
+        it("has the correct number of relatives") {
+          expect(testStruct.relatives.count).to(equal(2))
+        }
+
+        it("first relative is the relation struct") {
+          expect(testStruct.relatives[0]).to(equal(relationStruct))
+        }
+
+        it("first relative has the correct name") {
+          expect(testStruct.relatives[0].firstName).to(equal("Mini"))
+        }
+
+        it("second relative has the correct name") {
+          expect(testStruct.relatives[1].firstName).to(equal("Mini-Mini"))
+        }
+
+      }
+
+      context("array of objects") {
+        var testStruct: TestPersonStruct!
+        var relatives: [[String : Any]]!
+
+        beforeEach {
+          testStruct = TestPersonStruct([:])
+          relatives = [
+            [
+              "firstName" : "Mini",
+              "lastName" : "Swift",
+              "sex": "female",
+              "birth_date": "2014-07-17"
+            ],
+            [
+              "firstName" : "Mini-Mini",
+              "lastName" : "Swift",
+              "sex": "female",
+              "birth_date": "2014-07-18"
+            ]
+          ]
+          testStruct.relatives <- relatives.objects()
+
+        }
+
+        it("has the correct number of relatives") {
+          expect(testStruct.relatives.count).to(equal(2))
+        }
+
+      }
+
+      context("appending objects") {
+        var testStruct: TestPersonStruct!
+        var relatives: [[String : Any]]!
+
+        beforeEach {
+          testStruct = TestPersonStruct([:])
+          relatives =  [
+            [
+              "firstName" : "Mini",
+              "lastName" : "Swift",
+              "sex": "female",
+              "birth_date": "2014-07-17"
+            ],
+            [
+              "firstName" : "Mini-Mini",
+              "lastName" : "Swift",
+              "sex": "female",
+              "birth_date": "2014-07-18"
+            ]
+          ]
+
+          testStruct.relatives <+ relatives.objects()
+        }
+
+        it("has the correct relative count") {
+          expect(testStruct.relatives.count).to(equal(2))
+        }
+
+      }
+
+      context("appending object") {
+
+        var testStruct: TestPersonStruct!
+        var relatives: [String : Any]!
+        var copy: TestPersonStruct!
+
+        beforeEach {
+          testStruct = TestPersonStruct([:])
+          relatives = [
+            "first" : [
+              "firstName" : "Mini",
+              "lastName" : "Swift",
+              "sex": "female",
+              "birth_date": "2014-07-17"
+            ]
+          ]
+          testStruct.relatives <+ relatives.relation("first")
+          copy = testStruct
+        }
+
+        it("has one relative") {
+          expect(testStruct.relatives.count).to(equal(1))
+        }
+
+        context("after appending copy") {
+          beforeEach {
+            testStruct.relatives <+ copy
+          }
+
+          it("has two relatives") {
+            expect(testStruct.relatives.count).to(equal(2))
+          }
+        }
+      }
+
+      describe("value lookup") {
+        var personStruct: TestPersonStruct!
+
+        beforeEach {
+          personStruct = TestPersonStruct(
+            [
+              "firstName" : "Mini",
+              "lastName" : "Swift",
+              "sex": "female",
+              "birth_date": "2014-07-15"
+            ]
+          )
+        }
+
+        context("value lookup success") {
+          var firstName: String!
+          var lastName: String!
+
+          it("is successful") {
+            do {
+              firstName = try personStruct.value("firstName")
+              lastName = try personStruct.value("lastName")
+              expect(firstName).to(equal("Mini"))
+              expect(lastName).to(equal("Swift"))
+            } catch {}
+          }
+        }
+
+        context("value lookup failure") {
+
+          it("has a non-nil error") {
+            expect { try personStruct.value("123") }.to(throwError())
+          }
+
+        }
+
+      }
+
+      context("immutable object mapping") {
+
+        var immutableStruct: TestImmutable!
+        var expectedJob: Job!
+        beforeEach {
+          immutableStruct = try! TestImmutable(
+            [
+              "firstName" : "foo",
+              "lastName" : "bar",
+              "job" : ["name" : "Musician"],
+              "hobbies" : [["name" : "Musician"]]
+            ]
+          )
+          expectedJob = Job(["name" : "Musician"])
+        }
+
+        it("has the correct first name") {
+          expect(immutableStruct.firstName).to(equal("foo"))
+        }
+
+        it("has the correct last name") {
+          expect(immutableStruct.lastName).to(equal("bar"))
+        }
+
+        it("has the correct job") {
+          expect(immutableStruct.job.name).to(equal(expectedJob.name))
+        }
+
+        it("has the correct number of hobbies") {
+          expect(immutableStruct.hobbies.count).to(equal(1))
+        }
+
+        it("has the correct hobby") {
+          expect(immutableStruct.hobbies[0].name).to(equal(expectedJob.name))
+        }
+      }
+
+      context("Multiple types") {
+        var multiTypeStruct: MultipleTypeStruct!
+
+        beforeEach {
+          multiTypeStruct = MultipleTypeStruct(
+            [
+              "stringArray" : ["a", "b", "c"],
+              "stringDictionary" : ["a" : "a", "b" : "b", "c" : "c"],
+              "boolProperty" : true,
+              "people" : [
+                [
+                  "firstName" : "foo",
+                  "lastName" : "Swift",
+                  "sex": "female",
+                  "birth_date": "2014-07-15"
+                ],
+                [
+                  "firstName" : "bar",
+                  "lastName" : "Swift",
+                  "sex": "female",
+                  "birth_date": "2014-07-15"
+                ]
+              ],
+              "peopleDictionary" : ["Mini" : [
+                "firstName" : "Mini",
+                "lastName" : "Swift",
+                "sex": "female",
+                "birth_date": "2014-07-15"
+                ]
+              ]
+            ]
+          )
+        }
+
+        it("has the correct string array") {
+          expect(multiTypeStruct.stringArray).to(equal(["a", "b", "c"]))
+        }
+
+        it("has the correct string dict") {
+          expect(multiTypeStruct.stringDictionary).to(equal(["a" : "a", "b" : "b", "c" : "c"]))
+        }
+
+        it("has the correct bool property") {
+          expect(multiTypeStruct.boolProperty).to(beTruthy())
+        }
+
+        it("has the correct first name") {
+          expect(multiTypeStruct.people.first?.firstName).to(equal(TestPersonStruct(["firstName" : "foo"]).firstName))
+        }
+
+        it("has the correct people dict values") {
+          expect(multiTypeStruct.peopleDictionary["Mini"]?.firstName).to(equal(TestPersonStruct(["firstName" : "Mini"]).firstName))
+        }
+
+        it("has the correct last name on person 2") {
+          expect(multiTypeStruct.people[1].firstName).to(equal("bar"))
+        }
+
+      }
+
+      context("enumerations") {
+
+        enum State: String {
+          case Open = "open"
+          case Closed = "closed"
+        }
+
+        enum Priority: Int {
+          case low = 0
+          case medium = 1
+          case high = 2
+        }
+
+        struct Issue: Mappable {
+          var name: String = ""
+          var state: State = .Closed
+          var priority: Priority = .low
+
+          init(_ map: [String : Any]) {
+            self.name <- map.property("name")
+            self.state <- map.`enum`("state")
+            self.priority <- map.`enum`("priority")
+          }
+        }
+
+        var json: [String: Any]!
+        var issue: Issue!
+
+        beforeEach {
+          json = [
+            "name": "Swift 3 support",
+            "state": "open",
+            "priority": 2
+          ]
+          issue = Issue(json as [String : Any])
+        }
+
+        it("has the correct issue name") {
+          expect(issue.name).to(equal("Swift 3 support"))
+        }
+
+        it("Has the correct issue state") {
+          expect(issue.state).to(equal(State.Open))
+        }
+
+        it("has the correct issue priority") {
+          expect(issue.priority).to(equal(Priority.high))
+        }
+
+      }
+
+      context("Path") {
+
+        struct Person: Mappable {
+          var name: String = ""
+          var trueName: String = ""
+          var secret: String = ""
+          var identity: String = ""
+
+          init(_ map: [String : Any]) {
+            self.name <- map.resolve(keyPath: "info")?.property("name")
+            self.trueName <- map.resolve(keyPath: "info.true_info")?.property("true_name")
+            self.secret <- map.resolve(keyPath: "chaos.1.way.light.1")?.property("secret")
+            self.identity <- map.resolve(keyPath: "chaos.1.way.identity")?.property("night")
+          }
+        }
+
+
+        var json: [String: Any]!
+        var person: Person!
+
+        beforeEach {
+          json = [
+            "info": [
+              "name": "Elliot Alderson",
+              "true_info": [
+                "true_name": "Mr. Robot"
+              ]
+            ],
+            "chaos": [
+              [
+                "$": "@",
+                "!": "&"
+              ],
+              [
+                "way": [
+                  "light": [
+                    [
+                      "±": "§",
+                      "_": "="
+                    ],
+                    [
+                      "secret": "secret"
+                    ]
+                  ],
+                  "dark": ">\"<",
+                  "identity": [
+                    "day": "security",
+                    "night": "hacker"
+                  ]
+                ]
+              ]
+            ]
+          ]
+          person = Person(json as [String : Any])
+        }
+
+        it("has the correct name") {
+          expect(person.name).to(equal("Elliot Alderson"))
+        }
+
+        it("has the correct true name") {
+          expect(person.trueName).to(equal("Mr. Robot"))
+        }
+
+        it("has the correct secret") {
+          expect(person.secret).to(equal("secret"))
+        }
+
+        it("has the correct identity") {
+          expect(person.identity).to(equal("hacker"))
+        }
+
+      }
+
     }
+  }
 
 }

--- a/TailorTests/Shared/TestMappable.swift
+++ b/TailorTests/Shared/TestMappable.swift
@@ -230,13 +230,12 @@ class TestMappable: QuickSpec {
             ]
           ]
 
-          testStruct.relatives <+ relatives.objects()
+          testStruct.relatives += relatives.objects()
         }
 
         it("has the correct relative count") {
           expect(testStruct.relatives.count).to(equal(2))
         }
-
       }
 
       context("appending object") {
@@ -255,7 +254,7 @@ class TestMappable: QuickSpec {
               "birth_date": "2014-07-17"
             ]
           ]
-          testStruct.relatives <+ relatives.relation("first")
+          testStruct.relatives.append(relatives.relation("first")!)
           copy = testStruct
         }
 
@@ -265,7 +264,7 @@ class TestMappable: QuickSpec {
 
         context("after appending copy") {
           beforeEach {
-            testStruct.relatives <+ copy
+            testStruct.relatives.append(copy)
           }
 
           it("has two relatives") {

--- a/TailorTests/Shared/TestSubjects.swift
+++ b/TailorTests/Shared/TestSubjects.swift
@@ -80,10 +80,10 @@ struct TestImmutable: SafeMappable {
   let hobbies: [Job]
 
   init(_ map: [String : Any]) throws {
-    firstName = try <-map.property("firstName")
-    lastName = try <-map.property("lastName")
-    job = try <-map.relationOrThrow("job")
-    hobbies = try <-map.relationsOrThrow("hobbies")
+    firstName = try map.property("firstName").unwrapOrThrow()
+    lastName = try map.property("lastName").unwrapOrThrow()
+    job = try map.relation("job").unwrapOrThrow()
+    hobbies = try map.relations("hobbies").unwrapOrThrow()
   }
 }
 


### PR DESCRIPTION
- Remove all the `orThrow` method. This adds `unwrapOrThrow` on optional. So this is more like `Optional -> Throw`. We now don't need to have 2 methods
- Remove some custom operators. We don't really need these
- Also, re-indent all the test files to use 2 spaces